### PR TITLE
fix: tighten responsive layouts, align demo cards, and surface MFA verrify state

### DIFF
--- a/src/app/account/security/page.tsx
+++ b/src/app/account/security/page.tsx
@@ -55,7 +55,7 @@ export default function AccountSecurityPage() {
             <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
               Account · Security
             </p>
-            <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+            <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
               Lock things down
             </h1>
             <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">

--- a/src/app/account/security/page.tsx
+++ b/src/app/account/security/page.tsx
@@ -65,18 +65,22 @@ export default function AccountSecurityPage() {
           </div>
 
           <div className="space-y-6">
-            <MfaManagement
-              mfaEnabled={user.mfa_enabled || false}
-              onMfaStatusChange={() => {
-                // Trigger a refresh if needed
-              }}
-            />
+            <div className="rounded-3xl border border-slate-200/70 bg-white/85 p-6 shadow-sm backdrop-blur-md dark:border-slate-700/60 dark:bg-slate-900/65">
+              <MfaManagement
+                mfaEnabled={user.mfa_enabled || false}
+                onMfaStatusChange={() => {
+                  // Trigger a refresh if needed
+                }}
+              />
+            </div>
 
             <div className="rounded-3xl border border-slate-200/70 bg-white/85 p-6 shadow-sm backdrop-blur-md dark:border-slate-700/60 dark:bg-slate-900/65">
               <PasskeyManagement />
             </div>
 
-            <SessionsManagement userId={user.id} />
+            <div className="rounded-3xl border border-slate-200/70 bg-white/85 p-6 shadow-sm backdrop-blur-md dark:border-slate-700/60 dark:bg-slate-900/65">
+              <SessionsManagement userId={user.id} />
+            </div>
 
             <div className="relative overflow-hidden rounded-3xl border border-indigo-200/60 bg-gradient-to-br from-indigo-50/80 via-white to-violet-50/60 p-5 sm:p-6 dark:border-indigo-500/30 dark:from-indigo-500/10 dark:via-slate-900/40 dark:to-violet-500/10">
               <span

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -295,7 +295,7 @@ const DashboardPage = () => {
               <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
                 Dashboard
               </p>
-              <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+              <h1 className="mt-2 break-words text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
                 Welcome{user?.name ? `, ${user.name}` : ""}.
               </h1>
               <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
@@ -475,7 +475,7 @@ const DashboardPage = () => {
                     )}
 
                     {/* Stats — compact, with secondary descriptors */}
-                    <div className="grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
+                    <div className="grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-4">
                       {[
                         {
                           label: "Total picks",
@@ -573,7 +573,7 @@ const DashboardPage = () => {
                     </div>
 
                     {/* Library snapshot + Smart suggestion */}
-                    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                       {/* Library snapshot */}
                       <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-5 shadow-sm backdrop-blur-md dark:border-slate-700/60 dark:bg-slate-900/65">
                         <div className="mb-3 flex items-center justify-between">
@@ -801,7 +801,7 @@ const DashboardPage = () => {
                         transition={{ duration: 0.18 }}
                       >
                         {loading ? (
-                          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5">
                             {[...Array(10)].map((_, i) => (
                               <div
                                 key={i}
@@ -841,7 +841,7 @@ const DashboardPage = () => {
                             )}
                           </div>
                         ) : (
-                          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5">
                             {filteredPicks.slice(0, 15).map((rec) => {
                               const inLibrary = loggedTitleKeys.has(
                                 `${rec.type}::${rec.title.toLowerCase()}`,

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -7,6 +7,7 @@ import { motion } from "motion/react";
 const VALIDATION_FLASH_MS = 650;
 const VALIDATION_MESSAGE_MS = 3200;
 import { IconArrowRight, IconCheck } from "@tabler/icons-react";
+import { BookOpen, Film, Sparkles } from "lucide-react";
 
 import {
   useQuizStore,
@@ -26,8 +27,10 @@ import { PillButton } from "@/components/ui/pill-button";
 import { cn } from "@/lib/utils";
 
 interface DemoContentCardProps {
+  eyebrow: string;
   title: string;
   description: string;
+  icon: React.ReactNode;
   mediaSrc: string;
   secondaryMediaSrc?: string;
   isSelected: boolean;
@@ -35,33 +38,80 @@ interface DemoContentCardProps {
 }
 
 const DemoContentCard = ({
+  eyebrow,
   title,
   description,
+  icon,
   mediaSrc,
   secondaryMediaSrc,
   isSelected,
   onClick,
 }: DemoContentCardProps) => {
   return (
-    <PillButton
+    <button
+      type="button"
       onClick={onClick}
-      active={isSelected}
+      aria-pressed={isSelected}
       className={cn(
-        "relative w-full overflow-hidden rounded-3xl border p-0 text-left shadow-sm backdrop-blur-md transition-all duration-300 hover:-translate-y-1",
+        "group relative w-full overflow-hidden rounded-3xl border bg-white/85 text-left shadow-sm backdrop-blur-md transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-slate-900/65 dark:focus-visible:ring-offset-slate-950",
         isSelected
-          ? "border-indigo-500 bg-white shadow-lg dark:border-indigo-400 dark:bg-slate-900/70"
-          : "border-slate-200/80 bg-white/80 hover:border-indigo-300 hover:shadow-md dark:border-slate-700/70 dark:bg-slate-900/65 dark:hover:border-indigo-500/60",
+          ? "border-transparent shadow-indigo-500/15"
+          : "border-slate-200/70 hover:border-slate-300 dark:border-slate-700/60 dark:hover:border-slate-600/80",
       )}
     >
-      {isSelected && (
-        <div className="absolute right-3 top-3 z-10 inline-flex h-7 w-7 items-center justify-center rounded-full bg-indigo-500 text-white shadow-md">
-          <IconCheck className="h-4 w-4" />
-        </div>
-      )}
+      {/* Gradient accent ring when selected. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-3xl transition-opacity duration-300",
+          isSelected
+            ? "opacity-100 ring-2 ring-indigo-500/70 dark:ring-indigo-400/70"
+            : "opacity-0",
+        )}
+      />
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br from-indigo-500/[0.06] via-transparent to-violet-500/[0.06] transition-opacity duration-300 dark:from-indigo-400/[0.08] dark:to-violet-400/[0.08]",
+          isSelected ? "opacity-100" : "opacity-0",
+        )}
+      />
 
-      <div className="relative aspect-[16/9] overflow-hidden bg-slate-200 dark:bg-slate-800">
-        {secondaryMediaSrc ? (
-          <div className="grid h-full w-full grid-cols-2 gap-1 p-1">
+      {/* Selected check chip */}
+      <div
+        className={cn(
+          "absolute right-3 top-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 text-white shadow-lg shadow-indigo-500/30 transition-all duration-300",
+          isSelected ? "scale-100 opacity-100" : "scale-50 opacity-0",
+        )}
+      >
+        <IconCheck className="h-4 w-4" strokeWidth={3} />
+      </div>
+
+      {/* Mobile: horizontal layout (square thumb + content). md+: vertical. */}
+      <div className="flex md:block">
+        <div className="relative aspect-square w-28 shrink-0 overflow-hidden bg-slate-100 sm:w-32 md:aspect-[16/10] md:w-full dark:bg-slate-800/80">
+          {secondaryMediaSrc ? (
+            <div className="grid h-full w-full grid-cols-2 gap-1 p-1">
+              <video
+                src={mediaSrc}
+                autoPlay
+                loop
+                muted
+                playsInline
+                preload="auto"
+                className="h-full w-full rounded-xl object-cover md:rounded-2xl"
+              />
+              <video
+                src={secondaryMediaSrc}
+                autoPlay
+                loop
+                muted
+                playsInline
+                preload="auto"
+                className="h-full w-full rounded-xl object-cover md:rounded-2xl"
+              />
+            </div>
+          ) : (
             <video
               src={mediaSrc}
               autoPlay
@@ -69,62 +119,69 @@ const DemoContentCard = ({
               muted
               playsInline
               preload="auto"
-              className="h-full w-full rounded-lg object-cover"
+              className="h-full w-full object-contain p-2 transition-transform duration-500 group-hover:scale-105 md:p-3"
             />
-            <video
-              src={secondaryMediaSrc}
-              autoPlay
-              loop
-              muted
-              playsInline
-              preload="auto"
-              className="h-full w-full rounded-lg object-cover"
-            />
-          </div>
-        ) : (
-          <video
-            src={mediaSrc}
-            autoPlay
-            loop
-            muted
-            playsInline
-            preload="auto"
-            className="h-full w-full object-contain p-2"
-          />
-        )}
-      </div>
+          )}
+        </div>
 
-      <div className="p-4 sm:p-5">
-        <h3 className="text-xl font-black tracking-tight sm:text-2xl">
-          {title}
-        </h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-          {description}
-        </p>
+        <div className="relative flex-1 p-4 md:p-5">
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-full transition-colors duration-300",
+                isSelected
+                  ? "bg-indigo-500 text-white"
+                  : "bg-slate-100 text-slate-500 group-hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:group-hover:bg-slate-700",
+              )}
+            >
+              {icon}
+            </span>
+            <p
+              className={cn(
+                "text-[10px] font-black uppercase tracking-[0.18em] transition-colors duration-300",
+                isSelected
+                  ? "text-indigo-600 dark:text-indigo-400"
+                  : "text-slate-400 dark:text-slate-500",
+              )}
+            >
+              {eyebrow}
+            </p>
+          </div>
+          <h3 className="mt-2 text-lg font-black tracking-tight sm:text-xl md:text-2xl">
+            {title}
+          </h3>
+          <p className="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300 md:mt-1.5">
+            {description}
+          </p>
+        </div>
       </div>
-    </PillButton>
+    </button>
   );
 };
 
 const DEMO_CONTENT_CARDS = [
   {
     option: "Movies",
+    eyebrow: "On screen",
     title: "Movie",
-    description:
-      "Find a movie recommendation that fits your current mood and pace.",
+    description: "A film tuned to your current mood and pace.",
+    icon: <Film size={14} />,
     mediaSrc: "/animations/Popcorn.webm",
   },
   {
     option: "Books",
+    eyebrow: "On the shelf",
     title: "Book",
-    description:
-      "Get a reading recommendation tailored to your style and interests.",
+    description: "A read tailored to your style and interests.",
+    icon: <BookOpen size={14} />,
     mediaSrc: "/animations/Books.webm",
   },
   {
     option: "Both",
-    title: "Both",
-    description: "Get one movie and one book recommendation in the same flow.",
+    eyebrow: "Both",
+    title: "One of each",
+    description: "A movie and a book picked together in one go.",
+    icon: <Sparkles size={14} />,
     mediaSrc: "/animations/Popcorn.webm",
     secondaryMediaSrc: "/animations/Books.webm",
   },
@@ -277,12 +334,14 @@ export default function DemoPage() {
               onChange={setAnswer}
               bodyOverride={
                 current.id === "contentType" ? (
-                  <div className="mt-7 grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <div className="mt-5 grid grid-cols-1 gap-3 sm:mt-7 sm:gap-4 md:grid-cols-3">
                     {DEMO_CONTENT_CARDS.map((card) => (
                       <DemoContentCard
                         key={card.option}
+                        eyebrow={card.eyebrow}
                         title={card.title}
                         description={card.description}
+                        icon={card.icon}
                         mediaSrc={card.mediaSrc}
                         secondaryMediaSrc={
                           "secondaryMediaSrc" in card

--- a/src/app/demo/results/page.tsx
+++ b/src/app/demo/results/page.tsx
@@ -73,38 +73,38 @@ const DemoResultCard = ({ item, index }: { item: DemoItem; index: number }) => {
       transition={{ duration: 0.3, delay: index * 0.06 }}
       className="group overflow-hidden rounded-3xl border border-slate-200/70 bg-white/85 shadow-sm backdrop-blur-md transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg dark:border-slate-700/60 dark:bg-slate-900/65"
     >
-      <div className="grid grid-cols-1 sm:grid-cols-[168px_1fr]">
+      <div className="grid grid-cols-[112px_1fr] sm:grid-cols-[140px_1fr] md:grid-cols-[168px_1fr]">
         {/* Image */}
         <div className="relative aspect-[2/3] overflow-hidden bg-slate-200 dark:bg-slate-800">
           <Image
             src={item.image}
             alt={item.title}
             fill
-            sizes="(max-width: 640px) 100vw, 168px"
+            sizes="(max-width: 640px) 112px, (max-width: 768px) 140px, 168px"
             className="object-cover transition-transform duration-500 group-hover:scale-105"
           />
           {/* Type badge */}
-          <div className="absolute left-3 top-3 inline-flex items-center gap-1 rounded-full bg-black/60 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-white backdrop-blur-sm">
-            {item.type === "movie" ? <Film size={10} /> : <BookOpen size={10} />}
+          <div className="absolute left-1.5 top-1.5 inline-flex items-center gap-0.5 rounded-full bg-black/60 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-white backdrop-blur-sm sm:left-3 sm:top-3 sm:gap-1 sm:px-2.5 sm:py-1 sm:text-[10px]">
+            {item.type === "movie" ? <Film size={9} /> : <BookOpen size={9} />}
             {item.type}
           </div>
           {/* Match badge */}
           <div
             className={cn(
-              "absolute right-3 top-3 rounded-full px-2.5 py-1 text-[10px] font-bold shadow-sm backdrop-blur-sm",
+              "absolute right-1.5 top-1.5 rounded-full px-1.5 py-0.5 text-[9px] font-bold shadow-sm backdrop-blur-sm sm:right-3 sm:top-3 sm:px-2.5 sm:py-1 sm:text-[10px]",
               MATCH_TONE_CLASSES[matchTone],
             )}
           >
-            {matchScore}% match
+            {matchScore}%<span className="hidden sm:inline"> match</span>
           </div>
         </div>
 
         {/* Content */}
-        <div className="flex flex-col p-5 sm:p-6">
-          <h3 className="line-clamp-2 text-xl font-black tracking-tight sm:text-2xl">
+        <div className="flex flex-col p-3 sm:p-5 md:p-6">
+          <h3 className="line-clamp-2 text-base font-black tracking-tight sm:text-xl md:text-2xl">
             {item.title}
           </h3>
-          <p className="mt-1 text-sm font-medium text-slate-500 dark:text-slate-400">
+          <p className="mt-0.5 line-clamp-1 text-xs font-medium text-slate-500 sm:mt-1 sm:line-clamp-none sm:text-sm dark:text-slate-400">
             {item.subtitle}
           </p>
 
@@ -354,7 +354,7 @@ export default function DemoResultsPage() {
                 <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
                   Demo · Your picks
                 </p>
-                <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+                <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
                   Hand-picked for you
                 </h1>
                 <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -64,7 +64,7 @@ const sortOptions: { value: SortMode; label: string }[] = [
 
 const HistoryShimmerLoader = () => {
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {[...Array(10)].map((_, i) => (
         <div
           key={i}
@@ -255,6 +255,7 @@ const AccountHistoryPage = () => {
     const update = () => {
       const w = window.innerWidth;
       if (w >= 1280) setColCount(5);
+      else if (w >= 1024) setColCount(4);
       else if (w >= 768) setColCount(3);
       else setColCount(2);
     };
@@ -383,7 +384,7 @@ const AccountHistoryPage = () => {
               <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
                 History
               </p>
-              <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+              <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
                 Your suggestion history
               </h1>
               <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -178,7 +178,7 @@ export default function LibraryPage() {
               <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
                 Library
               </p>
-              <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+              <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
                 What you&apos;ve watched and read
               </h1>
               <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -172,7 +172,176 @@ const RecommendationCard = ({
       transition={{ duration: 0.32, delay: index * 0.06 }}
       className="group overflow-hidden rounded-3xl border border-slate-200/70 bg-white/85 shadow-sm backdrop-blur-md transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg dark:border-slate-700/60 dark:bg-slate-900/65"
     >
-      <div className="grid grid-cols-1 sm:grid-cols-[168px_1fr]">
+      {/* Mobile: poster + header on top; rich body below spans full width.
+          Desktop (sm+): grid with full poster column on the left. */}
+      <div className="flex gap-3 p-3 sm:hidden">
+        <div className="relative aspect-[2/3] w-24 shrink-0 overflow-hidden rounded-xl bg-slate-200 dark:bg-slate-800">
+          {rec.poster_url ? (
+            <Image
+              src={rec.poster_url}
+              alt={rec.title}
+              fill
+              sizes="96px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-slate-400">
+              {rec.type === "movie" ? (
+                <Film size={20} />
+              ) : (
+                <BookOpen size={20} />
+              )}
+            </div>
+          )}
+          <div
+            className={cn(
+              "absolute left-1 top-1 rounded-full px-1.5 py-0.5 text-[9px] font-bold shadow-sm backdrop-blur-sm",
+              MATCH_TONE_CLASSES[matchTone],
+            )}
+          >
+            {matchScore}%
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                {rec.type === "movie" ? (
+                  <Film size={9} />
+                ) : (
+                  <BookOpen size={9} />
+                )}
+                {rec.type}
+              </span>
+              <h2 className="mt-1 text-base font-black leading-tight tracking-tight">
+                {rec.title}
+              </h2>
+              <p className="mt-0.5 line-clamp-1 text-xs text-slate-500 dark:text-slate-400">
+                {rec.author
+                  ? `By ${rec.author}`
+                  : rec.director
+                    ? `Directed by ${rec.director}`
+                    : ""}
+                {rec.year ? ` · ${rec.year}` : ""}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onToggleFavorite(rec.id)}
+              aria-label={
+                rec.is_favorited
+                  ? `Remove ${rec.title} from favorites`
+                  : `Add ${rec.title} to favorites`
+              }
+              className={cn(
+                "shrink-0 rounded-full p-1.5 transition-all active:scale-[0.95]",
+                rec.is_favorited
+                  ? "bg-rose-500 text-white shadow-md"
+                  : "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+              )}
+            >
+              <Heart
+                size={13}
+                fill={rec.is_favorited ? "currentColor" : "none"}
+              />
+            </button>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {typeof rec.rating === "number" && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-1.5 py-0.5 text-[10px] font-bold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                <Star size={10} className="fill-current" />
+                {rec.rating}
+              </span>
+            )}
+            {rec.genres?.slice(0, 2).map((g) => (
+              <span
+                key={g}
+                className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+              >
+                {g}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile-only body (below the header strip) */}
+      <div className="space-y-3 px-3 pb-3 sm:hidden">
+        {explanation && (
+          <div className="relative overflow-hidden rounded-xl border border-indigo-200/60 bg-gradient-to-br from-indigo-50/80 via-white to-violet-50/60 p-3 dark:border-indigo-500/30 dark:from-indigo-500/10 dark:via-slate-900/40 dark:to-violet-500/10">
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-indigo-400 to-violet-500"
+            />
+            <div className="flex items-center gap-1.5 pl-2">
+              <Sparkles
+                size={12}
+                className="text-indigo-600 dark:text-indigo-400"
+              />
+              <p className="text-[10px] font-black uppercase tracking-[0.16em] text-indigo-700 dark:text-indigo-300">
+                Why this pick
+              </p>
+            </div>
+            <p className="mt-1.5 pl-2 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+              {explanation}
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-2">
+          <LogToLibraryButton
+            medium={rec.type}
+            title={rec.title}
+            creator={rec.author ?? rec.director ?? null}
+            year={rec.year ?? null}
+            poster_url={rec.poster_url ?? null}
+            source_recommendation_id={rec.id}
+            initialLogged={alreadyLogged}
+            variant="compact"
+          />
+        </div>
+
+        {showDescription && (
+          <div className="border-t border-slate-100 pt-3 dark:border-slate-800">
+            <p className="mb-1 text-[10px] font-black uppercase tracking-[0.16em] text-slate-400 dark:text-slate-500">
+              About
+            </p>
+            <p
+              className="overflow-hidden text-sm leading-relaxed text-slate-600 dark:text-slate-400"
+              style={
+                expanded
+                  ? undefined
+                  : {
+                      display: "-webkit-box",
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: "vertical",
+                    }
+              }
+            >
+              {description}
+            </p>
+            {description.length > 180 && (
+              <button
+                type="button"
+                onClick={() => setExpanded((prev) => !prev)}
+                className="mt-1.5 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-indigo-600 dark:text-indigo-400"
+              >
+                {expanded ? "Show less" : "Show more"}
+                <ChevronDown
+                  size={10}
+                  className={cn(
+                    "transition-transform duration-200",
+                    expanded && "rotate-180",
+                  )}
+                />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="hidden sm:grid sm:grid-cols-[168px_1fr]">
         {/* Poster */}
         <div className="relative aspect-[2/3] overflow-hidden bg-slate-200 dark:bg-slate-800">
           {rec.poster_url ? (
@@ -180,7 +349,7 @@ const RecommendationCard = ({
               src={rec.poster_url}
               alt={rec.title}
               fill
-              sizes="(max-width: 640px) 100vw, 168px"
+              sizes="168px"
               className="object-cover transition-transform duration-500 group-hover:scale-105"
             />
           ) : (
@@ -222,7 +391,6 @@ const RecommendationCard = ({
                 {rec.year ? ` · ${rec.year}` : ""}
               </p>
             </div>
-            {/* Action group — favorite + log together */}
             <div className="flex shrink-0 items-center gap-2">
               <LogToLibraryButton
                 medium={rec.type}
@@ -256,7 +424,6 @@ const RecommendationCard = ({
             </div>
           </div>
 
-          {/* Metadata row — rating + genres only, log button is now up top */}
           {(typeof rec.rating === "number" || rec.genres?.length) && (
             <div className="mt-3 flex flex-wrap items-center gap-2">
               {typeof rec.rating === "number" && (
@@ -276,8 +443,6 @@ const RecommendationCard = ({
             </div>
           )}
 
-          {/* "Why this pick" — promoted: gradient accent border, larger leading,
-              sparkles glyph to flag it as the AI's voice. */}
           {explanation && (
             <div className="relative mt-4 overflow-hidden rounded-2xl border border-indigo-200/60 bg-gradient-to-br from-indigo-50/80 via-white to-violet-50/60 p-4 dark:border-indigo-500/30 dark:from-indigo-500/10 dark:via-slate-900/40 dark:to-violet-500/10">
               <span
@@ -778,22 +943,21 @@ const ResultsPage = () => {
     <div className="min-h-screen w-full bg-slate-50 text-slate-900 antialiased transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
       {topBar}
 
-      <main className="px-4 pb-20 pt-32 md:pt-36 sm:px-6">
+      <main className="px-4 pb-20 pt-28 sm:px-6 md:pt-36">
         <div className="mx-auto max-w-6xl">
-          {/* Header */}
           <motion.div
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.35 }}
-            className="mb-8"
+            className="mb-6 sm:mb-8"
           >
-            <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
+            <p className="text-[10px] font-black uppercase tracking-[0.18em] text-indigo-500 sm:text-xs dark:text-indigo-400">
               Your picks
             </p>
-            <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+            <h1 className="mt-1.5 text-2xl font-black tracking-tighter sm:mt-2 sm:text-3xl md:text-4xl lg:text-5xl">
               Hand-picked for you
             </h1>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            <p className="mt-1.5 text-sm text-slate-500 sm:mt-2 dark:text-slate-400">
               {recommendations.length} personalized{" "}
               {recommendations.length === 1 ? "pick" : "picks"} from the AI,
               with the reasoning behind each. Log one to your library to nudge

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -614,7 +614,7 @@ const SettingsPage = () => {
               Settings
             </p>
             <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
-              Account Settings
+              Account settings
             </h1>
             <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
               Manage your profile, security, and preferences.
@@ -758,19 +758,19 @@ const SettingsPage = () => {
 
                     <SectionCard>
                       <SectionHeader
-                        title="Profile Details"
+                        title="Profile details"
                         description="Update your public account details."
                       />
                       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <SettingsInput
-                          label="Current Username"
+                          label="Current username"
                           defaultValue={user?.name || ""}
                           readOnly
                           disabled
                           icon={<CircleOff size={14} />}
                         />
                         <SettingsInput
-                          label="New Username"
+                          label="New username"
                           placeholder="Enter new username"
                           error={profileForm.formState.errors.newName?.message}
                           {...profileForm.register("newName")}
@@ -795,7 +795,7 @@ const SettingsPage = () => {
                           }
                           className="h-10 w-auto rounded-full px-6 text-sm font-semibold"
                         >
-                          Save Profile
+                          Save changes
                         </StatefulButton>
                       </div>
                     </SectionCard>
@@ -865,7 +865,7 @@ const SettingsPage = () => {
                         <div>
                           <div ref={newPasswordAnchorRef}>
                             <SettingsInput
-                              label="New Password"
+                              label="New password"
                               type="password"
                               placeholder="••••••••"
                               icon={<Lock size={14} />}
@@ -889,7 +889,7 @@ const SettingsPage = () => {
                         <div>
                           <div ref={confirmPasswordAnchorRef}>
                             <SettingsInput
-                              label="Confirm Password"
+                              label="Confirm password"
                               type="password"
                               placeholder="••••••••"
                               icon={<Lock size={14} />}
@@ -931,7 +931,7 @@ const SettingsPage = () => {
                       {!showMfaPanel ? (
                         <>
                           <SectionHeader
-                            title="Two-Factor Authentication"
+                            title="Two-factor authentication"
                             description="An extra step at sign-in to keep your account secure."
                           />
 
@@ -989,25 +989,17 @@ const SettingsPage = () => {
                           </div>
                         </>
                       ) : (
-                        <div>
-                          <button
-                            onClick={() => setShowMfaPanel(false)}
-                            className="mb-4 text-xs font-semibold text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
-                          >
-                            &larr; Back to Security
-                          </button>
-                          <MfaManagement
-                            key={mfaPanelKey}
-                            mfaEnabled={mfaEnabled}
-                            onMfaStatusChange={() => setShowMfaPanel(false)}
-                            onAddAuthenticator={() =>
-                              setMfaSetupModal({
-                                open: true,
-                                isAdditional: true,
-                              })
-                            }
-                          />
-                        </div>
+                        <MfaManagement
+                          key={mfaPanelKey}
+                          mfaEnabled={mfaEnabled}
+                          onMfaStatusChange={() => setShowMfaPanel(false)}
+                          onAddAuthenticator={() =>
+                            setMfaSetupModal({
+                              open: true,
+                              isAdditional: true,
+                            })
+                          }
+                        />
                       )}
                     </SectionCard>
 
@@ -1019,7 +1011,7 @@ const SettingsPage = () => {
                     {/* Backup Email */}
                     <SectionCard>
                       <SectionHeader
-                        title="Backup Email"
+                        title="Backup email"
                         description="A recovery address used when your authenticator is unavailable."
                       />
 
@@ -1069,13 +1061,17 @@ const SettingsPage = () => {
                           }
                           className="h-10 w-auto rounded-full px-6 text-sm font-semibold"
                         >
-                          {currentBackupEmail ? "Update Backup" : "Save Backup"}
+                          {currentBackupEmail ? "Update backup" : "Save backup"}
                         </StatefulButton>
                       </div>
                     </SectionCard>
 
                     {/* Sessions */}
-                    {user?.id && <SessionsManagement userId={user.id} />}
+                    {user?.id && (
+                      <SectionCard>
+                        <SessionsManagement userId={user.id} />
+                      </SectionCard>
+                    )}
                   </motion.div>
                 )}
 
@@ -1090,7 +1086,7 @@ const SettingsPage = () => {
                   >
                     <SectionCard>
                       <SectionHeader
-                        title="Content Preferences"
+                        title="Content preferences"
                         description="Set your default recommendation behavior."
                       />
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -613,7 +613,7 @@ const SettingsPage = () => {
             <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
               Settings
             </p>
-            <h1 className="mt-2 text-3xl font-black tracking-tighter sm:text-4xl md:text-5xl">
+            <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
               Account Settings
             </h1>
             <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">

--- a/src/components/ui/marquee-hero-images.tsx
+++ b/src/components/ui/marquee-hero-images.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { useEffect, useState } from "react";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface MarqueeRowProps {
+  images: string[];
+  reverse?: boolean;
+  duration: number;
+  className?: string;
+}
+
+const fadeMask =
+  "linear-gradient(to right, transparent, black 6%, black 94%, transparent)";
+
+const MarqueeRow = ({
+  images,
+  reverse = false,
+  duration,
+  className,
+}: MarqueeRowProps) => {
+  if (images.length === 0) return null;
+  const loop = [...images, ...images];
+
+  return (
+    <div
+      className={cn("overflow-hidden", className)}
+      style={{ maskImage: fadeMask, WebkitMaskImage: fadeMask }}
+    >
+      <motion.div
+        className="flex w-max"
+        animate={{ x: reverse ? ["-50%", "0%"] : ["0%", "-50%"] }}
+        transition={{ duration, ease: "linear", repeat: Infinity }}
+      >
+        {loop.map((src, i) => (
+          <div key={`${src}-${i}`} className="shrink-0 pr-3 sm:pr-4">
+            <div className="relative aspect-[2/3] h-28 overflow-hidden rounded-lg opacity-70 ring-1 ring-black/10 sm:h-36 md:h-44 dark:opacity-55 dark:ring-white/10">
+              <img
+                src={src}
+                alt=""
+                loading="eager"
+                decoding="async"
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            </div>
+          </div>
+        ))}
+      </motion.div>
+    </div>
+  );
+};
+
+export interface MarqueeHeroImagesProps {
+  images: string[];
+  className?: string;
+}
+
+export const MarqueeHeroImages = ({
+  images,
+  className,
+}: MarqueeHeroImagesProps) => {
+  const [snapshot, setSnapshot] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (snapshot.length === 0 && images.length > 0) {
+      setSnapshot(images);
+    }
+  }, [images, snapshot.length]);
+
+  if (snapshot.length === 0) return null;
+
+  const half = Math.max(3, Math.ceil(snapshot.length / 2));
+  const topRow = snapshot.slice(0, half);
+  const remainder = snapshot.slice(half);
+  const bottomRow =
+    remainder.length >= 3 ? remainder : [...topRow].reverse();
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-0 z-0 overflow-hidden",
+        className,
+      )}
+    >
+      <MarqueeRow
+        images={topRow}
+        duration={28}
+        className="absolute inset-x-0 top-14 sm:top-16"
+      />
+      <MarqueeRow
+        images={bottomRow}
+        reverse
+        duration={36}
+        className="absolute inset-x-0 bottom-20 sm:bottom-32"
+      />
+    </div>
+  );
+};

--- a/src/components/ui/parallax-hero-images.tsx
+++ b/src/components/ui/parallax-hero-images.tsx
@@ -200,7 +200,7 @@ const ParallaxImage = memo(function ParallaxImage({
 
   return (
     <motion.div
-      className="absolute aspect-[2/3] h-36 w-24 sm:h-52 sm:w-36 md:h-64 md:w-44"
+      className="absolute aspect-[2/3] h-36 w-24 sm:h-52 sm:w-36 md:h-60 md:w-40 lg:h-64 lg:w-44 xl:h-72 xl:w-48 2xl:h-80 2xl:w-52"
       style={{
         top: posStyle.top,
         left: posStyle.left,

--- a/src/features/auth/components/auth-form.tsx
+++ b/src/features/auth/components/auth-form.tsx
@@ -131,6 +131,7 @@ export const AuthForm = ({
   const [mfaCode, setMfaCode] = useState("");
   const [mfaInputMode, setMfaInputMode] = useState<"totp" | "backup">("totp");
   const [mfaVerifying, setMfaVerifying] = useState(false);
+  const [mfaSuccess, setMfaSuccess] = useState(false);
 
   // Passkey sign-in state
   const [passkeySupported, setPasskeySupported] = useState(false);
@@ -508,6 +509,33 @@ export const AuthForm = ({
     }
   };
 
+  /**
+   * Friendlier copy for the noisy error strings the auth APIs return on a
+   * wrong/expired code. Falls back to the raw error for anything we don't
+   * recognize so unusual cases (network errors, etc.) still surface.
+   */
+  const friendlyMfaError = (raw: string, mode: "totp" | "backup") => {
+    const normalized = raw.toLowerCase();
+    if (normalized.includes("expired")) {
+      return mode === "totp"
+        ? "That code expired. Wait for a new one in your authenticator and try again."
+        : "That backup code is no longer valid.";
+    }
+    if (
+      normalized.includes("invalid") ||
+      normalized.includes("incorrect") ||
+      normalized.includes("doesn't match") ||
+      normalized.includes("does not match") ||
+      normalized.includes("not match") ||
+      normalized.includes("wrong")
+    ) {
+      return mode === "totp"
+        ? "That code didn't match. Double-check your authenticator and try again."
+        : "That backup code didn't match. Each code only works once.";
+    }
+    return raw;
+  };
+
   const handleMfaVerify = async () => {
     resetFeedback();
     setMfaVerifying(true);
@@ -520,10 +548,14 @@ export const AuthForm = ({
         }
         const result = await onVerifyMFA(mfaFactorId, mfaCode);
         if (result.error) {
-          setErrors({ general: result.error });
+          setErrors({ general: friendlyMfaError(result.error, "totp") });
+          setMfaCode("");
         } else {
+          setMfaSuccess(true);
           onMfaChallengeResolved?.();
-          router.replace("/dashboard");
+          // Brief confirmation before the redirect so the verify success
+          // doesn't feel like a silent flash.
+          setTimeout(() => router.replace("/dashboard"), 2800);
         }
       } else {
         const trimmed = mfaCode.trim();
@@ -533,10 +565,12 @@ export const AuthForm = ({
         }
         const result = await onVerifyBackupCode(trimmed);
         if (result.error) {
-          setErrors({ general: result.error });
+          setErrors({ general: friendlyMfaError(result.error, "backup") });
+          setMfaCode("");
         } else {
+          setMfaSuccess(true);
           onMfaChallengeResolved?.();
-          router.replace("/dashboard");
+          setTimeout(() => router.replace("/dashboard"), 2800);
         }
       }
     } finally {
@@ -610,6 +644,7 @@ export const AuthForm = ({
               }}
               onVerify={handleMfaVerify}
               verifying={mfaVerifying}
+              success={mfaSuccess}
               error={formError}
               onBackToSignIn={() => toggleMode("signin")}
             />

--- a/src/features/auth/components/mfa-challenge-screen.tsx
+++ b/src/features/auth/components/mfa-challenge-screen.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { ShieldCheck, KeyRound } from "lucide-react";
+import { ShieldCheck, KeyRound, Check } from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
 import { AuthHoverButton } from "./auth-shared";
+import { cn } from "@/lib/utils";
 
 export const MfaChallengeScreen = ({
   mfaCode,
@@ -10,6 +12,7 @@ export const MfaChallengeScreen = ({
   onToggleMfaInputMode,
   onVerify,
   verifying,
+  success = false,
   error,
   onBackToSignIn,
 }: {
@@ -19,10 +22,39 @@ export const MfaChallengeScreen = ({
   onToggleMfaInputMode: () => void;
   onVerify: () => void;
   verifying: boolean;
+  /** Renders a green confirmation state for the brief window between
+   *  successful verification and the dashboard redirect. */
+  success?: boolean;
   error: string | null;
   onBackToSignIn: () => void;
 }) => {
   const isTotp = mfaInputMode === "totp";
+
+  if (success) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, scale: 0.96 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.25, ease: "easeOut" }}
+        className="flex flex-col items-center justify-center space-y-5 py-8 text-center"
+      >
+        <div className="rounded-full bg-emerald-100 p-4 dark:bg-emerald-900/30">
+          <Check
+            className="h-10 w-10 text-emerald-600 dark:text-emerald-400"
+            strokeWidth={3}
+          />
+        </div>
+        <div>
+          <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+            Verified
+          </h2>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+            Taking you to your dashboard…
+          </p>
+        </div>
+      </motion.div>
+    );
+  }
 
   return (
     <div className="flex flex-col items-center justify-center space-y-5 py-4 text-center">
@@ -53,7 +85,12 @@ export const MfaChallengeScreen = ({
             maxLength={6}
             value={mfaCode}
             onChange={(e) => onMfaCodeChange(e.target.value.replace(/\D/g, ""))}
-            className="w-full rounded-lg border-2 border-slate-200 bg-white px-4 py-4 text-center text-3xl font-bold tracking-[0.4em] text-slate-900 placeholder-slate-300 focus:border-violet-500 focus:outline-none focus:ring-4 focus:ring-violet-500/10 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:placeholder-slate-600"
+            className={cn(
+              "w-full rounded-lg border-2 bg-white px-4 py-4 text-center text-3xl font-bold tracking-[0.4em] text-slate-900 placeholder-slate-300 transition-colors focus:outline-none focus:ring-4 dark:bg-slate-900 dark:text-white dark:placeholder-slate-600",
+              error
+                ? "border-red-400 focus:border-red-500 focus:ring-red-500/15 dark:border-red-500/60"
+                : "border-slate-200 focus:border-violet-500 focus:ring-violet-500/10 dark:border-slate-700",
+            )}
             placeholder="000000"
             autoFocus
             onKeyDown={(e) => {
@@ -65,7 +102,12 @@ export const MfaChallengeScreen = ({
             type="text"
             value={mfaCode}
             onChange={(e) => onMfaCodeChange(e.target.value)}
-            className="w-full rounded-lg border-2 border-slate-200 bg-white px-4 py-3 text-center font-mono text-lg font-semibold tracking-wider text-slate-900 placeholder-slate-300 uppercase focus:border-violet-500 focus:outline-none focus:ring-4 focus:ring-violet-500/10 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:placeholder-slate-600"
+            className={cn(
+              "w-full rounded-lg border-2 bg-white px-4 py-3 text-center font-mono text-lg font-semibold tracking-wider text-slate-900 placeholder-slate-300 uppercase transition-colors focus:outline-none focus:ring-4 dark:bg-slate-900 dark:text-white dark:placeholder-slate-600",
+              error
+                ? "border-red-400 focus:border-red-500 focus:ring-red-500/15 dark:border-red-500/60"
+                : "border-slate-200 focus:border-violet-500 focus:ring-violet-500/10 dark:border-slate-700",
+            )}
             placeholder="XXXXX-XXXXX"
             autoFocus
             onKeyDown={(e) => {
@@ -74,9 +116,21 @@ export const MfaChallengeScreen = ({
           />
         )}
 
-        {error && (
-          <p className="mt-2 text-sm font-medium text-red-500">{error}</p>
-        )}
+        <AnimatePresence initial={false} mode="wait">
+          {error && (
+            <motion.p
+              key={error}
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={{ duration: 0.18 }}
+              role="alert"
+              className="mt-2 text-sm font-semibold text-red-500"
+            >
+              {error}
+            </motion.p>
+          )}
+        </AnimatePresence>
       </div>
 
       <div className="w-full max-w-xs space-y-3">

--- a/src/features/auth/components/mfa-management.tsx
+++ b/src/features/auth/components/mfa-management.tsx
@@ -13,12 +13,11 @@ import {
   Copy,
   Check,
   Download,
-  Plus,
   Pencil,
 } from "lucide-react";
 import { RenameDialog } from "./rename-dialog";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Button as StatefulButton } from "@/components/ui/stateful-button";
 import { toast } from "sonner";
 import { motion } from "motion/react";
 import { Dialog } from "@/components/ui/dialog";
@@ -192,46 +191,62 @@ export const MfaManagement = ({
     URL.revokeObjectURL(url);
   };
 
+  const hasFactors = mfaEnabled && factors.length > 0;
+  const lowBackupCodes =
+    backupCodeCount !== null && backupCodeCount <= 2 && backupCodeCount > 0;
+
   return (
-    <Card className="p-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-            Two-Factor Authentication
-          </h3>
-          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            {mfaEnabled
-              ? "Your account is protected with 2FA enabled"
-              : "Protect your account with two-factor authentication"}
-          </p>
-        </div>
-        {mfaEnabled && (
-          <div className="flex items-center gap-2 rounded-full bg-green-100 px-3 py-1 dark:bg-green-900/30">
-            <ShieldCheck className="h-4 w-4 text-green-600 dark:text-green-400" />
-            <span className="text-xs font-semibold text-green-600 dark:text-green-400">
-              Enabled
-            </span>
-          </div>
-        )}
+    <>
+      <div className="mb-5">
+        <h2 className="text-xl font-black tracking-tight sm:text-2xl">
+          Two-factor authentication
+        </h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          An extra step at sign-in to keep your account secure.
+        </p>
       </div>
 
-      {mfaEnabled && factors.length > 0 && (
-        <div className="mt-6 space-y-4">
-          <div className="text-sm font-medium text-slate-700 dark:text-slate-300">
-            Active authenticators:
-          </div>
+      <div className="flex items-center justify-between gap-3 rounded-xl border border-slate-200/70 bg-slate-50 px-4 py-3 dark:border-slate-700/60 dark:bg-slate-800/40">
+        <div className="flex items-center gap-2.5">
+          <ShieldCheck
+            size={16}
+            className={
+              mfaEnabled
+                ? "shrink-0 text-emerald-500 dark:text-emerald-400"
+                : "shrink-0 text-slate-400 dark:text-slate-500"
+            }
+          />
+          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+            {mfaEnabled
+              ? `${factors.length} authenticator${factors.length === 1 ? "" : "s"} active`
+              : "Not yet enabled"}
+          </span>
+        </div>
+        <span
+          className={
+            mfaEnabled
+              ? "shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+              : "shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+          }
+        >
+          {mfaEnabled ? "Enabled" : "Inactive"}
+        </span>
+      </div>
+
+      {hasFactors && (
+        <div className="mt-4 space-y-3">
           {factors.map((factor) => (
             <div
               key={factor.id}
-              className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-900/50"
+              className="flex items-center justify-between rounded-xl border border-slate-200/70 bg-white px-4 py-3 dark:border-slate-700/60 dark:bg-slate-900/40"
             >
               <div className="flex min-w-0 flex-1 items-center gap-3">
-                <ShieldCheck className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
+                <ShieldCheck className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
                 <div className="min-w-0 flex-1">
-                  <p className="truncate font-medium text-slate-900 dark:text-slate-100">
+                  <p className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
                     {prettifyFactorName(factor.friendly_name)}
                   </p>
-                  <p className="text-xs text-slate-600 dark:text-slate-400">
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
                     Added {format(new Date(factor.created_at), "PP")}
                   </p>
                 </div>
@@ -263,29 +278,19 @@ export const MfaManagement = ({
             </div>
           ))}
 
-          {onAddAuthenticator && (
-            <button
-              onClick={onAddAuthenticator}
-              className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-slate-300 bg-white/50 px-4 py-3 text-sm font-semibold text-slate-600 transition-colors hover:border-indigo-400 hover:bg-indigo-50/50 hover:text-indigo-600 dark:border-slate-700 dark:bg-slate-900/30 dark:text-slate-300 dark:hover:border-indigo-500 dark:hover:bg-indigo-900/10 dark:hover:text-indigo-400"
-            >
-              <Plus className="h-4 w-4" />
-              Add another authenticator
-            </button>
-          )}
-
           {/* Backup Codes Section */}
-          <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-900/50">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <KeyRound className="h-5 w-5 text-slate-600 dark:text-slate-400" />
-                <div>
-                  <p className="font-medium text-slate-900 dark:text-slate-100">
-                    Backup Codes
+          <div className="rounded-xl border border-slate-200/70 bg-white px-4 py-3 dark:border-slate-700/60 dark:bg-slate-900/40">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <KeyRound className="h-5 w-5 shrink-0 text-slate-600 dark:text-slate-400" />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                    Backup codes
                   </p>
-                  <p className="text-xs text-slate-600 dark:text-slate-400">
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
                     {backupCodeCount !== null
-                      ? `${backupCodeCount} unused codes remaining`
-                      : "Loading..."}
+                      ? `${backupCodeCount} unused code${backupCodeCount === 1 ? "" : "s"} remaining`
+                      : "Loading…"}
                   </p>
                 </div>
               </div>
@@ -300,14 +305,19 @@ export const MfaManagement = ({
                     setShowRegeneratePanel(true);
                   }
                 }}
-                className="text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+                aria-label={
+                  showRegeneratePanel
+                    ? "Hide backup codes panel"
+                    : "Show backup codes panel"
+                }
+                className="text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
               >
                 <RefreshCw className="h-4 w-4" />
               </Button>
             </div>
 
             {showRegeneratePanel && (
-              <div className="mt-4 border-t border-slate-200 pt-4 dark:border-slate-700">
+              <div className="mt-4 border-t border-slate-200/70 pt-4 dark:border-slate-700/60">
                 {newBackupCodes.length === 0 ? (
                   <div>
                     <p className="mb-3 text-xs text-slate-600 dark:text-slate-400">
@@ -324,19 +334,19 @@ export const MfaManagement = ({
                       ) : (
                         <RefreshCw className="mr-2 h-3 w-3" />
                       )}
-                      {regenerating ? "Generating..." : "Generate New Codes"}
+                      {regenerating ? "Generating…" : "Generate new codes"}
                     </Button>
                   </div>
                 ) : (
                   <div>
                     <p className="mb-3 text-xs font-bold uppercase tracking-wider text-amber-700 dark:text-amber-400">
-                      Save these codes — they won't be shown again
+                      Save these codes — they won&apos;t be shown again
                     </p>
                     <div className="grid grid-cols-2 gap-2">
                       {newBackupCodes.map((code, i) => (
                         <code
                           key={i}
-                          className="rounded bg-white px-2 py-1.5 text-center font-mono text-xs font-semibold text-slate-800 dark:bg-slate-800 dark:text-slate-200"
+                          className="rounded bg-slate-50 px-2 py-1.5 text-center font-mono text-xs font-semibold text-slate-800 dark:bg-slate-800/60 dark:text-slate-200"
                         >
                           {code}
                         </code>
@@ -350,7 +360,7 @@ export const MfaManagement = ({
                         className="flex-1"
                       >
                         {backupCodesCopied ? (
-                          <Check className="mr-1 h-3 w-3 text-green-500" />
+                          <Check className="mr-1 h-3 w-3 text-emerald-500" />
                         ) : (
                           <Copy className="mr-1 h-3 w-3" />
                         )}
@@ -372,8 +382,8 @@ export const MfaManagement = ({
             )}
           </div>
 
-          {backupCodeCount !== null && backupCodeCount <= 2 && (
-            <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+          {lowBackupCodes && (
+            <p className="rounded-xl border border-amber-200/70 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
               You have {backupCodeCount} backup code
               {backupCodeCount !== 1 ? "s" : ""} remaining. Consider
               regenerating new codes.
@@ -383,14 +393,29 @@ export const MfaManagement = ({
       )}
 
       {!mfaEnabled && (
-        <div className="mt-6">
-          <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
-            Enable 2FA to add an extra layer of security to your account. You'll
-            need to verify with your authenticator app.
-          </p>
-          <Button disabled>{loading ? "Loading..." : "Enable 2FA"}</Button>
-        </div>
+        <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+          Enable 2FA to add an extra layer of security at sign-in. You&apos;ll
+          verify with your authenticator app.
+        </p>
       )}
+
+      <div className="mt-5 flex justify-end">
+        {mfaEnabled && onAddAuthenticator ? (
+          <StatefulButton
+            onClick={onAddAuthenticator}
+            className="h-10 w-auto rounded-full px-6 text-sm font-semibold"
+          >
+            Add authenticator
+          </StatefulButton>
+        ) : !mfaEnabled ? (
+          <StatefulButton
+            disabled
+            className="h-10 w-auto rounded-full px-6 text-sm font-semibold"
+          >
+            {loading ? "Loading…" : "Enable 2FA"}
+          </StatefulButton>
+        ) : null}
+      </div>
 
       <RenameDialog
         open={renameTarget !== null}
@@ -494,6 +519,6 @@ export const MfaManagement = ({
           </div>
         </div>
       </Dialog>
-    </Card>
+    </>
   );
 };

--- a/src/features/auth/components/passkey-management.tsx
+++ b/src/features/auth/components/passkey-management.tsx
@@ -161,7 +161,9 @@ export const PasskeyManagement = () => {
   return (
     <>
       <div className="mb-5">
-        <h2 className="text-xl font-bold tracking-tight">Passkeys</h2>
+        <h2 className="text-xl font-black tracking-tight sm:text-2xl">
+          Passkeys
+        </h2>
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
           Sign in with your fingerprint, face, or device PIN — no password
           needed.

--- a/src/features/auth/components/sessions-management.tsx
+++ b/src/features/auth/components/sessions-management.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { sessionManagementService } from "../services/session-management";
 import { authService } from "../services/auth-service";
-import { LogOut, Smartphone, Globe, LogOutIcon } from "lucide-react";
+import { Loader, LogOut, Smartphone, Globe, LogOutIcon } from "lucide-react";
 import {
   IconBrandChrome,
   IconBrandFirefox,
@@ -12,9 +12,8 @@ import {
   IconBrandEdge,
   IconBrandOpera,
 } from "@tabler/icons-react";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { formatLastActivity } from "../utils/device";
 
 /**
@@ -121,112 +120,137 @@ export const SessionsManagement = ({ userId }: SessionsManagementProps) => {
 
   if (loading) {
     return (
-      <Card className="p-6">
-        <div className="flex items-center justify-center py-8">
-          <div className="animate-spin">
-            <Smartphone className="h-5 w-5 text-slate-400" />
-          </div>
+      <>
+        <div className="mb-5">
+          <h2 className="text-xl font-black tracking-tight sm:text-2xl">Active sessions</h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Manage devices currently signed in to your account.
+          </p>
         </div>
-      </Card>
+        <div className="flex items-center justify-center rounded-xl border border-slate-200/70 bg-slate-50 py-8 dark:border-slate-700/60 dark:bg-slate-800/40">
+          <Smartphone className="h-5 w-5 animate-spin text-slate-400" />
+        </div>
+      </>
     );
   }
 
+  const hasSessions = sessions.length > 0;
+
   return (
-    <Card className="p-6">
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-            Active Sessions
-          </h3>
-          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            Manage your active sessions and devices. Sign out to revoke access.
-          </p>
+    <>
+      <div className="mb-5">
+        <h2 className="text-xl font-black tracking-tight sm:text-2xl">
+          Active sessions
+        </h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Manage devices currently signed in to your account. Sign out to
+          revoke access.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200/70 bg-slate-50 px-4 py-3 dark:border-slate-700/60 dark:bg-slate-800/40">
+        <div className="flex items-center gap-2.5">
+          <Globe
+            size={16}
+            className={
+              hasSessions
+                ? "shrink-0 text-emerald-500 dark:text-emerald-400"
+                : "shrink-0 text-slate-400 dark:text-slate-500"
+            }
+          />
+          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+            {hasSessions
+              ? `${sessions.length} device${sessions.length === 1 ? "" : "s"} signed in`
+              : "No active sessions"}
+          </span>
         </div>
         {sessions.length > 1 && (
-          <Button
-            variant="ghost"
-            size="sm"
+          <button
+            type="button"
             onClick={handleRevokeAll}
             disabled={signingOutAll}
-            className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
+            className="group inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-white px-3 py-1.5 text-xs font-bold tracking-tight text-red-600 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-red-300 hover:bg-red-50 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 dark:border-red-500/30 dark:bg-slate-900/60 dark:text-red-400 dark:hover:border-red-500/60 dark:hover:bg-red-500/10"
           >
-            <LogOutIcon className="h-4 w-4 mr-2" />
-            {signingOutAll ? "Signing out..." : "Sign Out All"}
-          </Button>
+            <LogOutIcon className="h-3.5 w-3.5 transition-transform duration-200 group-hover:-translate-x-0.5" />
+            {signingOutAll ? "Signing out…" : "Sign out all"}
+          </button>
         )}
       </div>
 
-      {sessions.length === 0 ? (
-        <div className="text-center py-8">
-          <Smartphone className="h-12 w-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
-          <p className="text-slate-600 dark:text-slate-400">
+      {!hasSessions ? (
+        <div className="mt-4 rounded-xl border border-dashed border-slate-200 bg-white/60 px-6 py-8 text-center dark:border-slate-700/60 dark:bg-slate-900/40">
+          <Smartphone
+            className="mx-auto mb-2 h-8 w-8 text-slate-300 dark:text-slate-600"
+            aria-hidden="true"
+          />
+          <p className="text-sm text-slate-500 dark:text-slate-400">
             No active sessions found
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="mt-4 space-y-3">
           {sessions.map((session) => {
             const BrowserIcon = getBrowserIcon(session.browser_name);
             return (
-            <div
-              key={session.id}
-              className={`flex items-start justify-between rounded-lg border px-4 py-4 transition-colors ${
-                session.is_current_device
-                  ? "border-blue-200 bg-blue-50 dark:border-blue-900/30 dark:bg-blue-900/20"
-                  : "border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/50"
-              }`}
-            >
-              <div className="flex items-start gap-3 flex-1">
-                <div className="mt-1">
-                  {session.device_type === "mobile" ? (
-                    <Smartphone className="h-5 w-5 text-slate-600 dark:text-slate-400" />
-                  ) : (
-                    <BrowserIcon className="h-5 w-5 text-slate-600 dark:text-slate-400" />
-                  )}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <p className="font-semibold text-slate-900 dark:text-slate-100 truncate">
-                      {session.device_name}
-                    </p>
-                    {session.is_current_device && (
-                      <span className="inline-block px-2 py-1 text-xs font-semibold text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30 rounded-full whitespace-nowrap">
-                        Current
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">
-                    {session.os_name} &bull; {session.browser_name}{" "}
-                    {session.browser_version}
-                  </p>
-                  {session.ip_address && (
-                    <p className="text-xs text-slate-500 dark:text-slate-500 mt-1">
-                      IP: {session.ip_address}
-                    </p>
-                  )}
-                  <p className="text-xs text-slate-500 dark:text-slate-500 mt-2">
-                    Last active: {formatLastActivity(session.last_activity)}
-                  </p>
-                </div>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => handleRevokeSession(session)}
-                disabled={revoking === session.id || signingOutAll}
-                className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20 ml-2"
-              >
-                {revoking === session.id ? (
-                  <span className="h-4 w-4 animate-spin">&#8987;</span>
-                ) : (
-                  <LogOut className="h-4 w-4" />
+              <div
+                key={session.id}
+                className={cn(
+                  "flex items-start justify-between gap-3 rounded-xl border px-4 py-3 transition-colors",
+                  session.is_current_device
+                    ? "border-emerald-200/70 bg-emerald-50/60 dark:border-emerald-500/30 dark:bg-emerald-500/10"
+                    : "border-slate-200/70 bg-white dark:border-slate-700/60 dark:bg-slate-900/40",
                 )}
-              </Button>
-            </div>
+              >
+                <div className="flex min-w-0 flex-1 items-start gap-3">
+                  {session.device_type === "mobile" ? (
+                    <Smartphone className="mt-0.5 h-5 w-5 shrink-0 text-slate-600 dark:text-slate-400" />
+                  ) : (
+                    <BrowserIcon className="mt-0.5 h-5 w-5 shrink-0 text-slate-600 dark:text-slate-400" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                        {session.device_name}
+                      </p>
+                      {session.is_current_device && (
+                        <span className="shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300">
+                          Current
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      {session.os_name} · {session.browser_name}{" "}
+                      {session.browser_version}
+                    </p>
+                    {session.ip_address && (
+                      <p className="text-xs text-slate-400 dark:text-slate-500">
+                        IP {session.ip_address}
+                      </p>
+                    )}
+                    <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                      Last active {formatLastActivity(session.last_activity)}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRevokeSession(session)}
+                  disabled={revoking === session.id || signingOutAll}
+                  aria-label={`Sign out of ${session.device_name}`}
+                  title={`Sign out of ${session.device_name}`}
+                  className="shrink-0 inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200/80 bg-white text-red-600 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-red-300 hover:bg-red-50 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-red-400 dark:hover:border-red-500/60 dark:hover:bg-red-500/10"
+                >
+                  {revoking === session.id ? (
+                    <Loader className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <LogOut className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
             );
           })}
         </div>
       )}
-    </Card>
+    </>
   );
 };

--- a/src/features/home/components/hero-section.tsx
+++ b/src/features/home/components/hero-section.tsx
@@ -154,7 +154,7 @@ const HeroSection = () => {
     <section className="relative flex min-h-screen min-h-[100svh] w-full items-center justify-center overflow-hidden bg-slate-50 px-4 py-24 transition-colors duration-300 sm:px-6 sm:py-28 dark:bg-slate-950">
       <ParallaxHeroImages
         images={heroImages}
-        className="hidden md:block"
+        className="hidden lg:block"
       />
 
       <div className="relative z-10 mx-auto flex max-w-5xl flex-col items-center gap-6 text-center sm:gap-8">

--- a/src/features/home/components/hero-section.tsx
+++ b/src/features/home/components/hero-section.tsx
@@ -6,6 +6,7 @@ import { motion } from "motion/react";
 import { IconChevronsDown } from "@tabler/icons-react";
 import { FlipWords } from "@/components/ui/flip-words";
 import { HoverBorderGradient } from "@/components/ui/hover-border-gradient";
+import { MarqueeHeroImages } from "@/components/ui/marquee-hero-images";
 import { ParallaxHeroImages } from "@/components/ui/parallax-hero-images";
 import { PillButton } from "@/components/ui/pill-button";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -152,6 +153,7 @@ const HeroSection = () => {
 
   return (
     <section className="relative flex min-h-screen min-h-[100svh] w-full items-center justify-center overflow-hidden bg-slate-50 px-4 py-24 transition-colors duration-300 sm:px-6 sm:py-28 dark:bg-slate-950">
+      <MarqueeHeroImages images={heroImages} className="lg:hidden" />
       <ParallaxHeroImages
         images={heroImages}
         className="hidden lg:block"


### PR DESCRIPTION
Mobile + tablet pass across results, demo, dashboard, library, history, settings, and account/security: H1s now step text-2xl → text-3xl → text-4xl → text-5xl across the breakpoints instead of jumping straight from text-3xl to text-5xl at md, dashboard stats and library/suggestion grids fan out to multi-column at md (iPad portrait) instead of waiting for lg, the recent-picks grid hits 4 columns earlier, and the history virtualizer adds the missing 1024-1279 step. Results card was a ~700-900px-tall vertical stack on mobile; it now uses a separate horizontal mobile layout (small poster + heading strip, then a full- width body for the AI explanation, log button, and about) while keeping the original desktop grid intact. Demo results card got matching responsive poster sizes.

Demo content-selection card rebuilt to match the main quiz: proper button, gradient ring + check chip on selection, eyebrow + icon row, and the same horizontal-mobile / vertical-md+ layout.

Hero parallax media moves from md+ to lg+ so the imagery doesn't crowd the centered hero text on iPad portrait, and the per-image sizing now scales up through xl/2xl for big-monitor desktops.

MFA challenge screen finally tells the user what happened: raw API errors are mapped to "That code didn't match…" or expired-code copy, the input clears and turns red on failure, and a green Check "Verified" panel sits on screen for 2.8 seconds before the dashboard redirect so the success isn't a silent flash.