### PR TITLE
  Dashboard, library, passkeys, mobile polish, and auth flow fixes

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -593,9 +593,10 @@ const DashboardPage = () => {
                           <button
                             type="button"
                             onClick={() => router.push("/library")}
-                            className="text-[11px] font-bold tracking-tight text-indigo-600 transition-colors hover:text-indigo-500 dark:text-indigo-400"
+                            className="inline-flex items-center gap-1 rounded-full border border-slate-200/80 bg-white/80 px-3 py-1.5 text-xs font-bold tracking-tight text-slate-700 transition-colors hover:border-slate-300 hover:bg-white dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/70"
                           >
                             View all
+                            <ArrowRight size={12} />
                           </button>
                         </div>
                         {libraryItems.length === 0 ? (

--- a/src/components/ui/marquee-hero-images.tsx
+++ b/src/components/ui/marquee-hero-images.tsx
@@ -33,7 +33,17 @@ const MarqueeRow = ({
         transition={{ duration, ease: "linear", repeat: Infinity }}
       >
         {loop.map((src, i) => (
-          <div key={`${src}-${i}`} className="shrink-0 pr-3 sm:pr-4">
+          <motion.div
+            key={`${src}-${i}`}
+            className="shrink-0 pr-3 sm:pr-4"
+            initial={{ opacity: 0, filter: "blur(6px)" }}
+            animate={{ opacity: 1, filter: "blur(0px)" }}
+            transition={{
+              duration: 0.55,
+              delay: (i % images.length) * 0.06,
+              ease: [0.25, 0.1, 0.25, 1],
+            }}
+          >
             <div className="relative aspect-[2/3] h-28 overflow-hidden rounded-lg opacity-70 ring-1 ring-black/10 sm:h-36 md:h-44 dark:opacity-55 dark:ring-white/10">
               <img
                 src={src}
@@ -43,7 +53,7 @@ const MarqueeRow = ({
                 className="absolute inset-0 h-full w-full object-cover"
               />
             </div>
-          </div>
+          </motion.div>
         ))}
       </motion.div>
     </div>

--- a/src/components/ui/resizable-navbar.tsx
+++ b/src/components/ui/resizable-navbar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { IconMenu2, IconX } from "@tabler/icons-react";
 import {
   motion,
   AnimatePresence,
@@ -242,17 +241,48 @@ export const MobileNavMenu = ({ children, isOpen }: { children: React.ReactNode;
   </AnimatePresence>
 );
 
-export const MobileNavToggle = ({ isOpen, onClick }: { isOpen: boolean; onClick: () => void }) => (
-  <button
-    onClick={onClick}
-    className="rounded-full p-2 text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800"
-    aria-label={isOpen ? "Close menu" : "Open menu"}
-    aria-expanded={isOpen}
-    aria-controls="mobile-nav-menu"
-  >
-    {isOpen ? <IconX /> : <IconMenu2 />}
-  </button>
-);
+export const MobileNavToggle = ({
+  isOpen,
+  onClick,
+}: {
+  isOpen: boolean;
+  onClick: () => void;
+}) => {
+  const transition = {
+    duration: 0.3,
+    ease: [0.22, 1, 0.36, 1] as [number, number, number, number],
+  };
+  const lineClass = "absolute left-0 h-0.5 w-6 rounded-full bg-current";
+  return (
+    <button
+      onClick={onClick}
+      className="rounded-full p-2 text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800"
+      aria-label={isOpen ? "Close menu" : "Open menu"}
+      aria-expanded={isOpen}
+      aria-controls="mobile-nav-menu"
+    >
+      <span className="relative block h-6 w-6">
+        <motion.span
+          className={cn(lineClass, "top-[5px]")}
+          animate={isOpen ? { rotate: 45, y: 6 } : { rotate: 0, y: 0 }}
+          transition={transition}
+        />
+        <motion.span
+          className={cn(lineClass, "top-[11px]")}
+          animate={
+            isOpen ? { opacity: 0, scaleX: 0 } : { opacity: 1, scaleX: 1 }
+          }
+          transition={transition}
+        />
+        <motion.span
+          className={cn(lineClass, "top-[17px]")}
+          animate={isOpen ? { rotate: -45, y: -6 } : { rotate: 0, y: 0 }}
+          transition={transition}
+        />
+      </span>
+    </button>
+  );
+};
 
 export const NavbarLogo = () => (
   <Link

--- a/src/features/auth/components/auth-form.tsx
+++ b/src/features/auth/components/auth-form.tsx
@@ -596,11 +596,11 @@ export const AuthForm = ({
     <div
       className={cn(
         "mx-auto w-full max-w-md overflow-hidden rounded-2xl border border-slate-200/70 bg-white/85 p-5 shadow-sm backdrop-blur-md transition-all duration-300 dark:border-slate-700/60 dark:bg-slate-900/65 sm:p-6",
-        mode === "signup" && "min-h-[620px]",
-        mode === "signin" && "min-h-[500px]",
-        mode === "forgot" && "min-h-[430px]",
-        mode === "verify-email" && "min-h-[400px]",
-        mode === "mfa-challenge" && "min-h-[440px]",
+        mode === "signup" && "md:min-h-[620px]",
+        mode === "signin" && "md:min-h-[500px]",
+        mode === "forgot" && "md:min-h-[430px]",
+        mode === "verify-email" && "md:min-h-[400px]",
+        mode === "mfa-challenge" && "md:min-h-[440px]",
       )}
     >
       <AnimatePresence mode="wait">

--- a/src/features/auth/components/auth-layout.tsx
+++ b/src/features/auth/components/auth-layout.tsx
@@ -13,9 +13,9 @@ interface AuthLayoutProps {
 
 export const AuthLayout = ({ children, onLogoClick }: AuthLayoutProps) => {
   return (
-    <main className="relative flex h-screen items-center overflow-hidden bg-slate-50 px-4 py-4 dark:bg-slate-950 md:px-8 md:py-8">
+    <main className="relative min-h-screen min-h-[100svh] bg-slate-50 px-4 py-4 dark:bg-slate-950 md:flex md:h-screen md:items-center md:overflow-hidden md:px-8 md:py-8">
       <div className="relative mx-auto grid w-full max-w-6xl grid-cols-1 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/80 shadow-[0_25px_80px_-40px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 md:grid-cols-2">
-        <section className="relative flex min-h-[540px] flex-col p-5 sm:p-7 md:min-h-[620px] md:p-8">
+        <section className="relative flex flex-col p-5 sm:p-7 md:min-h-[620px] md:p-8">
           <div className="mb-7 flex items-center justify-between">
             <button
               onClick={onLogoClick}


### PR DESCRIPTION
 ## Summary

  Bundles everything on `dev` since PR #7 merged. Major themes:

  - **Dashboard rebuild** — last-pick spotlight, filterable recent picks with status badges, library snapshot, taste-signal call-out, and unified "View all" pill styling across the overview.
  - **Passkeys + MFA** — passkey sign-in and management end-to-end, user-named MFA factors with rename/dedupe and step-up confirmation, dropped forced MFA at sign-in, auto-submit TOTP codes.
  - **Mobile/responsive polish** — new auto-scrolling cover marquee on the hero for `<lg` screens (replaces the empty space where the desktop parallax was hidden), animated hamburger ↔ X morph in the mobile navbar, auth page now scrolls naturally on mobile instead of clipping the form, tighter content-selection and demo card layouts, navbar hash-link offsets.
  - **Auth flow fixes** — expired-link callback params now clear after resend/mode switch, post-verification flows route to dashboard instead of content selection, MFA verify success state surfaces before redirect, sentence-case +
  sign-in/sign-up copy.
  - **Design language** — unified modal primitive, aligned security section styling, README cleanup (drop H1, lean on SVG wordmark).

  ## Test plan

  - [ ] Mobile viewport: hero shows two cover strips drifting in opposite directions, items fade in on first load and don't reset on subsequent media refreshes
  - [ ] Mobile navbar: tap hamburger → smooth morph to X, tap again → morph back
  - [ ] `/auth` on a phone: signup form scrolls past the viewport instead of clipping; expired verification link shows resend and clears params after click
  - [ ] Dashboard: both "View all" buttons (last-pick + taste signal) use the same pill + chevron style
  - [ ] Library: log a watched item from a result → it shows up in the dashboard library snapshot and influences the next quiz
  - [ ] Passkeys: register a passkey in settings, sign in with it (skips MFA challenge cleanly)
  - [ ] MFA: rename a TOTP factor, add a second one, verify backup-code path on the challenge screen
  - [ ] Verify the post-signup verified flow lands on dashboard, not content selection