### PR TITLE
Server-side AAL2 gate for sensitive operations

### DIFF
--- a/src/app/account/mfa-setup/page.tsx
+++ b/src/app/account/mfa-setup/page.tsx
@@ -2,15 +2,25 @@
 
 import { useAuth } from "@/features/auth/hooks/use-auth";
 import { MfaSetup } from "@/features/auth/components/mfa-setup";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 import { PageLoader } from "@/components/ui/loader";
 import { AppNavbar } from "@/components/app-navbar";
+import {
+  getMfaSetupCompleteTarget,
+  getMfaSetupSkipTarget,
+} from "@/lib/auth/post-verify";
 
-export default function MfaSetupPage() {
+function MfaSetupContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user, session, loading } = useAuth();
   const [mounted, setMounted] = useState(false);
+
+  const completeTarget = getMfaSetupCompleteTarget(
+    searchParams?.get("from") ?? null,
+  );
+  const skipTarget = getMfaSetupSkipTarget();
 
   useEffect(() => {
     setMounted(true);
@@ -38,14 +48,22 @@ export default function MfaSetupPage() {
         <div className="w-full max-w-md">
           <MfaSetup
             onComplete={() => {
-              router.push("/account/security");
+              router.push(completeTarget);
             }}
             onSkip={() => {
-              router.push("/dashboard");
+              router.push(skipTarget);
             }}
           />
         </div>
       </main>
     </div>
+  );
+}
+
+export default function MfaSetupPage() {
+  return (
+    <Suspense fallback={<PageLoader text="Loading..." />}>
+      <MfaSetupContent />
+    </Suspense>
   );
 }

--- a/src/app/api/account/delete/route.test.ts
+++ b/src/app/api/account/delete/route.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { requireAal2Mock, deleteUserMock, fromMock } = vi.hoisted(() => ({
+  requireAal2Mock: vi.fn(),
+  deleteUserMock: vi.fn(),
+  fromMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({
+  requireAal2: requireAal2Mock,
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: fromMock,
+    auth: { admin: { deleteUser: deleteUserMock } },
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://test.local/api/account/delete", {
+    method: "POST",
+  });
+}
+
+function chainedDelete(): {
+  delete: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+} {
+  const eq = vi.fn().mockResolvedValue({ error: null });
+  const del = vi.fn(() => ({ eq }));
+  return { delete: del, eq };
+}
+
+describe("POST /api/account/delete", () => {
+  beforeEach(() => {
+    requireAal2Mock.mockReset();
+    deleteUserMock.mockReset();
+    fromMock.mockReset();
+  });
+
+  it("(negative) rejects AAL1 sessions with the helper's 403 response", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("AAL2_REQUIRED");
+    expect(deleteUserMock).not.toHaveBeenCalled();
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("(negative) rejects unauthenticated with 401", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(401);
+    expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it("(positive) deletes account when caller is at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-123", email: "u@example.com" },
+      token: "jwt",
+    });
+    fromMock.mockImplementation(() => chainedDelete());
+    deleteUserMock.mockResolvedValue({ data: null, error: null });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+    expect(deleteUserMock).toHaveBeenCalledWith("user-123");
+    expect(fromMock).toHaveBeenCalledWith("sessions");
+    expect(fromMock).toHaveBeenCalledWith("mfa_factors");
+    expect(fromMock).toHaveBeenCalledWith("profiles");
+  });
+
+  it("returns 500 when admin deleteUser fails", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-123" },
+      token: "jwt",
+    });
+    fromMock.mockImplementation(() => chainedDelete());
+    deleteUserMock.mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requireAal2 } from "@/lib/auth/aal";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 
 export async function POST(request: NextRequest) {
@@ -14,33 +14,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const auth = await requireAal2(request);
+    if (!auth.ok) return auth.response;
+    const { user } = auth;
 
-    const token = authHeader.slice(7);
-
-    // Verify the user's identity with their JWT
-    const userClient = createClient(supabaseUrl, supabaseAnonKey);
-    const {
-      data: { user },
-      error: userError,
-    } = await userClient.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Use admin client with service role key
     const adminClient = createClient(supabaseUrl, supabaseServiceKey);
 
-    // Delete user data from tables
     await adminClient.from("sessions").delete().eq("user_id", user.id);
     await adminClient.from("mfa_factors").delete().eq("user_id", user.id);
     await adminClient.from("profiles").delete().eq("id", user.id);
 
-    // Delete the auth user
     const { error: deleteError } = await adminClient.auth.admin.deleteUser(
       user.id,
     );

--- a/src/app/api/account/disable/route.test.ts
+++ b/src/app/api/account/disable/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { requireAal2Mock, updateUserByIdMock, fromMock } = vi.hoisted(() => ({
+  requireAal2Mock: vi.fn(),
+  updateUserByIdMock: vi.fn(),
+  fromMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({
+  requireAal2: requireAal2Mock,
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: fromMock,
+    auth: { admin: { updateUserById: updateUserByIdMock } },
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://test.local/api/account/disable", {
+    method: "POST",
+  });
+}
+
+function chainedUpdate() {
+  const eq = vi.fn().mockResolvedValue({ error: null });
+  const update = vi.fn(() => ({ eq }));
+  return { update };
+}
+
+describe("POST /api/account/disable", () => {
+  beforeEach(() => {
+    requireAal2Mock.mockReset();
+    updateUserByIdMock.mockReset();
+    fromMock.mockReset();
+  });
+
+  it("(negative) rejects AAL1 sessions with 403", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(403);
+    expect(updateUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("(negative) rejects unauthenticated with 401", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(401);
+    expect(updateUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("(positive) bans the user when caller is at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-456" },
+      token: "jwt",
+    });
+    updateUserByIdMock.mockResolvedValue({ data: null, error: null });
+    fromMock.mockImplementation(() => chainedUpdate());
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(200);
+    expect(updateUserByIdMock).toHaveBeenCalledWith(
+      "user-456",
+      expect.objectContaining({ ban_duration: expect.any(String) }),
+    );
+    expect(fromMock).toHaveBeenCalledWith("sessions");
+  });
+
+  it("returns 500 when banning fails", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-456" },
+      token: "jwt",
+    });
+    updateUserByIdMock.mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/account/disable/route.ts
+++ b/src/app/api/account/disable/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requireAal2 } from "@/lib/auth/aal";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 
 export async function POST(request: NextRequest) {
@@ -14,25 +14,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const auth = await requireAal2(request);
+    if (!auth.ok) return auth.response;
+    const { user } = auth;
 
-    const token = authHeader.slice(7);
-
-    // Verify the user's identity with their JWT
-    const userClient = createClient(supabaseUrl, supabaseAnonKey);
-    const {
-      data: { user },
-      error: userError,
-    } = await userClient.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Use admin client to ban/disable the user
     const adminClient = createClient(supabaseUrl, supabaseServiceKey);
 
     const { error: banError } = await adminClient.auth.admin.updateUserById(
@@ -48,7 +33,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Revoke all sessions in the sessions table
     await adminClient
       .from("sessions")
       .update({ revoked_at: new Date().toISOString() })

--- a/src/app/api/account/email/route.test.ts
+++ b/src/app/api/account/email/route.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { requireAal2Mock, authRestUpdateUserMock } = vi.hoisted(() => ({
+  requireAal2Mock: vi.fn(),
+  authRestUpdateUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({ requireAal2: requireAal2Mock }));
+vi.mock("@/lib/auth/supabase-rest", () => ({
+  authRestUpdateUser: authRestUpdateUserMock,
+}));
+
+import { POST } from "./route";
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest("http://test.local/api/account/email", {
+    method: "POST",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/account/email", () => {
+  beforeEach(() => {
+    requireAal2Mock.mockReset();
+    authRestUpdateUserMock.mockReset();
+  });
+
+  it("(negative) rejects AAL1 with 403 AAL2_REQUIRED", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await POST(makeReq({ email: "new@example.com" }));
+
+    expect(res.status).toBe(403);
+    expect(authRestUpdateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed email with 400", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+
+    const res = await POST(makeReq({ email: "not-an-email" }));
+
+    expect(res.status).toBe(400);
+    expect(authRestUpdateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing email with 400", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+
+    const res = await POST(makeReq({}));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("(positive) updates email at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    authRestUpdateUserMock.mockResolvedValue({
+      ok: true,
+      data: {},
+      status: 200,
+    });
+
+    const res = await POST(makeReq({ email: "  NEW@example.COM  " }));
+
+    expect(res.status).toBe(200);
+    expect(authRestUpdateUserMock).toHaveBeenCalledWith("jwt", {
+      email: "new@example.com",
+    });
+  });
+
+  it("forwards Supabase error status", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    authRestUpdateUserMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      error: { message: "email already in use" },
+    });
+
+    const res = await POST(makeReq({ email: "taken@example.com" }));
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("email already in use");
+  });
+});

--- a/src/app/api/account/email/route.ts
+++ b/src/app/api/account/email/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAal2 } from "@/lib/auth/aal";
+import { authRestUpdateUser } from "@/lib/auth/supabase-rest";
+import { isValidEmail, normalizeEmail } from "@/features/auth/utils/validation";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAal2(request);
+  if (!auth.ok) return auth.response;
+  const { token } = auth;
+
+  let body: { email?: unknown };
+  try {
+    body = (await request.json()) as { email?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.email !== "string") {
+    return NextResponse.json(
+      { error: "Email is required." },
+      { status: 400 },
+    );
+  }
+  const newEmail = normalizeEmail(body.email);
+  if (!isValidEmail(newEmail)) {
+    return NextResponse.json(
+      { error: "Enter a valid email address." },
+      { status: 400 },
+    );
+  }
+
+  const result = await authRestUpdateUser(token, { email: newEmail });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/account/mfa/factor/[id]/route.test.ts
+++ b/src/app/api/account/mfa/factor/[id]/route.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const {
+  requireAal2Mock,
+  rpcRestRenameFactorMock,
+  authRestUnenrollFactorMock,
+} = vi.hoisted(() => ({
+  requireAal2Mock: vi.fn(),
+  rpcRestRenameFactorMock: vi.fn(),
+  authRestUnenrollFactorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({ requireAal2: requireAal2Mock }));
+vi.mock("@/lib/auth/supabase-rest", () => ({
+  rpcRestRenameFactor: rpcRestRenameFactorMock,
+  authRestUnenrollFactor: authRestUnenrollFactorMock,
+}));
+
+import { PATCH, DELETE } from "./route";
+
+function makeReq(method: "PATCH" | "DELETE", body?: unknown): NextRequest {
+  return new NextRequest("http://test.local/api/account/mfa/factor/abc", {
+    method,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const params = Promise.resolve({ id: "factor-abc" });
+
+describe("PATCH /api/account/mfa/factor/[id]", () => {
+  beforeEach(() => {
+    requireAal2Mock.mockReset();
+    rpcRestRenameFactorMock.mockReset();
+  });
+
+  it("(negative) rejects AAL1 with 403 AAL2_REQUIRED", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await PATCH(makeReq("PATCH", { friendlyName: "iPhone" }), {
+      params,
+    });
+
+    expect(res.status).toBe(403);
+    expect(rpcRestRenameFactorMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty body with 400", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+
+    const res = await PATCH(makeReq("PATCH", { friendlyName: "  " }), {
+      params,
+    });
+
+    expect(res.status).toBe(400);
+    expect(rpcRestRenameFactorMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects names over 64 chars with 400", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+
+    const res = await PATCH(
+      makeReq("PATCH", { friendlyName: "x".repeat(65) }),
+      { params },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("(positive) renames factor at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    rpcRestRenameFactorMock.mockResolvedValue({
+      ok: true,
+      data: true,
+      status: 200,
+    });
+
+    const res = await PATCH(makeReq("PATCH", { friendlyName: "iPad" }), {
+      params,
+    });
+
+    expect(res.status).toBe(200);
+    expect(rpcRestRenameFactorMock).toHaveBeenCalledWith(
+      "jwt",
+      "factor-abc",
+      "iPad",
+    );
+  });
+
+  it("returns 404 when RPC returns false (factor not found)", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    rpcRestRenameFactorMock.mockResolvedValue({
+      ok: true,
+      data: false,
+      status: 200,
+    });
+
+    const res = await PATCH(makeReq("PATCH", { friendlyName: "iPad" }), {
+      params,
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 on unique-violation (23505)", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    rpcRestRenameFactorMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      error: { message: "duplicate key value violates unique constraint (23505)" },
+    });
+
+    const res = await PATCH(makeReq("PATCH", { friendlyName: "Existing" }), {
+      params,
+    });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("DELETE /api/account/mfa/factor/[id]", () => {
+  beforeEach(() => {
+    requireAal2Mock.mockReset();
+    authRestUnenrollFactorMock.mockReset();
+  });
+
+  it("(negative) rejects AAL1 with 403 AAL2_REQUIRED", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await DELETE(makeReq("DELETE"), { params });
+
+    expect(res.status).toBe(403);
+    expect(authRestUnenrollFactorMock).not.toHaveBeenCalled();
+  });
+
+  it("(positive) unenrolls factor at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    authRestUnenrollFactorMock.mockResolvedValue({
+      ok: true,
+      data: { id: "factor-abc" },
+      status: 200,
+    });
+
+    const res = await DELETE(makeReq("DELETE"), { params });
+
+    expect(res.status).toBe(200);
+    expect(authRestUnenrollFactorMock).toHaveBeenCalledWith(
+      "jwt",
+      "factor-abc",
+    );
+  });
+
+  it("forwards Supabase error status", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    authRestUnenrollFactorMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      error: { message: "cannot unenroll" },
+    });
+
+    const res = await DELETE(makeReq("DELETE"), { params });
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/src/app/api/account/mfa/factor/[id]/route.ts
+++ b/src/app/api/account/mfa/factor/[id]/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAal2 } from "@/lib/auth/aal";
+import {
+  authRestUnenrollFactor,
+  rpcRestRenameFactor,
+} from "@/lib/auth/supabase-rest";
+
+/**
+ * Rename or delete a Supabase MFA factor.
+ *
+ * Both operations require AAL2 — by definition the user already has at least
+ * one verified factor (the one they're managing), so the bootstrap exception
+ * doesn't apply.
+ *
+ * Rename forwards to the existing rename_mfa_factor RPC (auth.uid() ownership
+ * check inside SQL). Delete forwards to Supabase Auth's REST DELETE on the
+ * factor; the auth server itself enforces AAL2 on verified-factor unenroll,
+ * but we keep the app-level gate for a consistent error shape.
+ */
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAal2(request);
+  if (!auth.ok) return auth.response;
+  const { token } = auth;
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing factor id" }, { status: 400 });
+  }
+
+  let body: { friendlyName?: unknown };
+  try {
+    body = (await request.json()) as { friendlyName?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const trimmed =
+    typeof body.friendlyName === "string" ? body.friendlyName.trim() : "";
+  if (!trimmed) {
+    return NextResponse.json(
+      { error: "Name cannot be empty." },
+      { status: 400 },
+    );
+  }
+  if (trimmed.length > 64) {
+    return NextResponse.json(
+      { error: "Name is too long (64 character max)." },
+      { status: 400 },
+    );
+  }
+
+  const result = await rpcRestRenameFactor(token, id, trimmed);
+  if (!result.ok) {
+    if (result.error.message.includes("23505")) {
+      return NextResponse.json(
+        { error: "You already have an authenticator with that name." },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: result.status },
+    );
+  }
+
+  if (result.data === false) {
+    return NextResponse.json(
+      { error: "Authenticator not found." },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, friendly_name: trimmed });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAal2(request);
+  if (!auth.ok) return auth.response;
+  const { token } = auth;
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing factor id" }, { status: 400 });
+  }
+
+  const result = await authRestUnenrollFactor(token, id);
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/account/mfa/totp/enroll/route.test.ts
+++ b/src/app/api/account/mfa/totp/enroll/route.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  getUserMock,
+  getAalMock,
+  authRestListFactorsMock,
+  authRestEnrollTotpMock,
+} = vi.hoisted(() => ({
+  getUserMock: vi.fn(),
+  getAalMock: vi.fn(),
+  authRestListFactorsMock: vi.fn(),
+  authRestEnrollTotpMock: vi.fn(),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ auth: { getUser: getUserMock } }),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({ getAal: getAalMock }));
+
+vi.mock("@/lib/auth/supabase-rest", () => ({
+  authRestListFactors: authRestListFactorsMock,
+  authRestEnrollTotp: authRestEnrollTotpMock,
+}));
+
+import { POST } from "./route";
+
+function makeReq(authHeader?: string, body?: unknown): NextRequest {
+  const headers = new Headers();
+  if (authHeader) headers.set("authorization", authHeader);
+  return new NextRequest("http://test.local/api/account/mfa/totp/enroll", {
+    method: "POST",
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/account/mfa/totp/enroll", () => {
+  beforeEach(() => {
+    getUserMock.mockReset();
+    getAalMock.mockReset();
+    authRestListFactorsMock.mockReset();
+    authRestEnrollTotpMock.mockReset();
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    expect(authRestEnrollTotpMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: { message: "x" },
+    });
+    const res = await POST(makeReq("Bearer bad"));
+    expect(res.status).toBe(401);
+    expect(authRestEnrollTotpMock).not.toHaveBeenCalled();
+  });
+
+  it("(bootstrap) enrolls at AAL1 when user has no verified factors", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [{ id: "f1", factor_type: "totp", status: "unverified" }],
+      status: 200,
+    });
+    authRestEnrollTotpMock.mockResolvedValue({
+      ok: true,
+      data: { id: "f2", type: "totp", totp: { qr_code: "qr", secret: "s" } },
+      status: 200,
+    });
+
+    const res = await POST(makeReq("Bearer good", { friendlyName: "iPhone" }));
+
+    expect(res.status).toBe(200);
+    expect(getAalMock).not.toHaveBeenCalled();
+    expect(authRestEnrollTotpMock).toHaveBeenCalledWith("good", "iPhone");
+  });
+
+  it("(negative) requires AAL2 when user already has a verified factor", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [{ id: "f1", factor_type: "totp", status: "verified" }],
+      status: 200,
+    });
+    getAalMock.mockResolvedValue("aal1");
+
+    const res = await POST(makeReq("Bearer good"));
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("AAL2_REQUIRED");
+    expect(authRestEnrollTotpMock).not.toHaveBeenCalled();
+  });
+
+  it("(positive) enrolls a second factor at AAL2", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [{ id: "f1", factor_type: "totp", status: "verified" }],
+      status: 200,
+    });
+    getAalMock.mockResolvedValue("aal2");
+    authRestEnrollTotpMock.mockResolvedValue({
+      ok: true,
+      data: { id: "f3", type: "totp" },
+      status: 200,
+    });
+
+    const res = await POST(makeReq("Bearer good"));
+
+    expect(res.status).toBe(200);
+    expect(authRestEnrollTotpMock).toHaveBeenCalled();
+  });
+
+  it("returns 502 if listFactors fails", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    authRestListFactorsMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      error: { message: "upstream" },
+    });
+
+    const res = await POST(makeReq("Bearer good"));
+    expect(res.status).toBe(502);
+    expect(authRestEnrollTotpMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards Supabase enroll error status", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+      status: 200,
+    });
+    authRestEnrollTotpMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      error: { message: "duplicate friendly name" },
+    });
+
+    const res = await POST(makeReq("Bearer good"));
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("duplicate friendly name");
+  });
+});

--- a/src/app/api/account/mfa/totp/enroll/route.ts
+++ b/src/app/api/account/mfa/totp/enroll/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getAal } from "@/lib/auth/aal";
+import {
+  authRestEnrollTotp,
+  authRestListFactors,
+} from "@/lib/auth/supabase-rest";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+/**
+ * Enroll a TOTP factor.
+ *
+ * Bootstrap exception: a user with no verified factor enrolls at AAL1 — that's
+ * the whole point of bootstrapping MFA. Once a verified factor exists, adding
+ * a second factor requires AAL2 (re-verifying the existing factor first).
+ *
+ * The bootstrap check reads factors from Supabase Auth's REST surface, which
+ * enforces ownership against the JWT subject — not from the public mirror
+ * table that A4-04 flagged as forgeable.
+ */
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const token = authHeader.slice(7);
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return NextResponse.json(
+      { error: "Server configuration error." },
+      { status: 500 },
+    );
+  }
+
+  const anonClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data: userData, error: userError } =
+    await anonClient.auth.getUser(token);
+  if (userError || !userData.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const factorsResult = await authRestListFactors(token);
+  if (!factorsResult.ok) {
+    return NextResponse.json(
+      { error: "Couldn't read MFA state. Please try again." },
+      { status: 502 },
+    );
+  }
+
+  const hasVerifiedFactor = factorsResult.data.some(
+    (f) => f.status === "verified",
+  );
+
+  if (hasVerifiedFactor) {
+    const aal = await getAal(token);
+    if (aal !== "aal2") {
+      return NextResponse.json(
+        {
+          error: "Step-up required. Verify your second factor to continue.",
+          code: "AAL2_REQUIRED",
+        },
+        { status: 403 },
+      );
+    }
+  }
+
+  let body: { friendlyName?: unknown } = {};
+  try {
+    body = (await request.json()) as { friendlyName?: unknown };
+  } catch {
+    // friendlyName is optional
+  }
+  const friendlyName =
+    typeof body.friendlyName === "string" && body.friendlyName.trim()
+      ? body.friendlyName.trim().slice(0, 64)
+      : undefined;
+
+  const enrollResult = await authRestEnrollTotp(token, friendlyName);
+  if (!enrollResult.ok) {
+    return NextResponse.json(
+      { error: enrollResult.error.message },
+      { status: enrollResult.status },
+    );
+  }
+
+  return NextResponse.json(enrollResult.data);
+}

--- a/src/app/api/account/password/route.test.ts
+++ b/src/app/api/account/password/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { requireAal2Mock, authRestUpdateUserMock } = vi.hoisted(() => ({
+  requireAal2Mock: vi.fn(),
+  authRestUpdateUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({ requireAal2: requireAal2Mock }));
+vi.mock("@/lib/auth/supabase-rest", () => ({
+  authRestUpdateUser: authRestUpdateUserMock,
+}));
+
+import { POST } from "./route";
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest("http://test.local/api/account/password", {
+    method: "POST",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/account/password", () => {
+  beforeEach(() => {
+    requireAal2Mock.mockReset();
+    authRestUpdateUserMock.mockReset();
+  });
+
+  it("(negative) rejects AAL1 with 403 AAL2_REQUIRED", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await POST(makeReq({ password: "ValidP@ss123" }));
+
+    expect(res.status).toBe(403);
+    expect(authRestUpdateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects weak password with 400", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+
+    const res = await POST(makeReq({ password: "short" }));
+
+    expect(res.status).toBe(400);
+    expect(authRestUpdateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("(positive) updates password at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    authRestUpdateUserMock.mockResolvedValue({
+      ok: true,
+      data: {},
+      status: 200,
+    });
+
+    const res = await POST(makeReq({ password: "ValidP@ss123" }));
+
+    expect(res.status).toBe(200);
+    expect(authRestUpdateUserMock).toHaveBeenCalledWith("jwt", {
+      password: "ValidP@ss123",
+    });
+  });
+
+  it("forwards Supabase error status", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "u1" },
+      token: "jwt",
+    });
+    authRestUpdateUserMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      error: { message: "same as old password" },
+    });
+
+    const res = await POST(makeReq({ password: "ValidP@ss123" }));
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/src/app/api/account/password/route.ts
+++ b/src/app/api/account/password/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAal2 } from "@/lib/auth/aal";
+import { authRestUpdateUser } from "@/lib/auth/supabase-rest";
+import { isValidPassword } from "@/features/auth/utils/validation";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAal2(request);
+  if (!auth.ok) return auth.response;
+  const { token } = auth;
+
+  let body: { password?: unknown };
+  try {
+    body = (await request.json()) as { password?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.password !== "string") {
+    return NextResponse.json(
+      { error: "Password is required." },
+      { status: 400 },
+    );
+  }
+  if (!isValidPassword(body.password)) {
+    return NextResponse.json(
+      {
+        error:
+          "Password must be at least 8 characters with uppercase, lowercase, number, and special character.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await authRestUpdateUser(token, { password: body.password });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/passkey/[id]/route.test.ts
+++ b/src/app/api/passkey/[id]/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { requireAal2Mock, getAdminClientMock, fromMock } = vi.hoisted(() => ({
+  requireAal2Mock: vi.fn(),
+  getAdminClientMock: vi.fn(),
+  fromMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/aal", () => ({ requireAal2: requireAal2Mock }));
+vi.mock("../_lib", () => ({ getAdminClient: getAdminClientMock }));
+
+import { PATCH, DELETE } from "./route";
+
+beforeEach(() => {
+  requireAal2Mock.mockReset();
+  getAdminClientMock.mockReset();
+  fromMock.mockReset();
+  getAdminClientMock.mockReturnValue({ from: fromMock });
+});
+
+function makeReq(method: "PATCH" | "DELETE", body?: unknown): NextRequest {
+  return new NextRequest("http://test.local/api/passkey/abc", {
+    method,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const params = Promise.resolve({ id: "passkey-abc" });
+
+function chainedDelete() {
+  const finalPromise = Promise.resolve({ error: null });
+  const eq2 = vi.fn(() => finalPromise);
+  const eq1 = vi.fn(() => ({ eq: eq2 }));
+  const del = vi.fn(() => ({ eq: eq1 }));
+  return { from: vi.fn(() => ({ delete: del })) };
+}
+
+function chainedUpdate() {
+  const finalPromise = Promise.resolve({ error: null });
+  const eq2 = vi.fn(() => finalPromise);
+  const eq1 = vi.fn(() => ({ eq: eq2 }));
+  const update = vi.fn(() => ({ eq: eq1 }));
+  return { from: vi.fn(() => ({ update })) };
+}
+
+describe("DELETE /api/passkey/[id]", () => {
+  it("(negative) rejects AAL1 with 403 AAL2_REQUIRED", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await DELETE(makeReq("DELETE"), { params });
+
+    expect(res.status).toBe(403);
+    expect(getAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  it("(positive) deletes passkey at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-1" },
+      token: "jwt",
+    });
+    const adminMock = chainedDelete();
+    getAdminClientMock.mockReturnValue(adminMock);
+
+    const res = await DELETE(makeReq("DELETE"), { params });
+
+    expect(res.status).toBe(200);
+    expect(adminMock.from).toHaveBeenCalledWith("user_passkeys");
+  });
+});
+
+describe("PATCH /api/passkey/[id]", () => {
+  it("(negative) rejects AAL1 with 403 AAL2_REQUIRED", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { error: "Step-up required.", code: "AAL2_REQUIRED" },
+        { status: 403 },
+      ),
+    });
+
+    const res = await PATCH(makeReq("PATCH", { device_name: "iPhone" }), {
+      params,
+    });
+
+    expect(res.status).toBe(403);
+    expect(getAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty name with 400", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-1" },
+      token: "jwt",
+    });
+
+    const res = await PATCH(makeReq("PATCH", { device_name: "  " }), {
+      params,
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("(positive) renames passkey at AAL2", async () => {
+    requireAal2Mock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-1" },
+      token: "jwt",
+    });
+    const adminMock = chainedUpdate();
+    getAdminClientMock.mockReturnValue(adminMock);
+
+    const res = await PATCH(makeReq("PATCH", { device_name: "iPad" }), {
+      params,
+    });
+
+    expect(res.status).toBe(200);
+    expect(adminMock.from).toHaveBeenCalledWith("user_passkeys");
+  });
+});

--- a/src/app/api/passkey/[id]/route.ts
+++ b/src/app/api/passkey/[id]/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAdminClient, getUserFromAuthHeader } from "../_lib";
+import { requireAal2 } from "@/lib/auth/aal";
+import { getAdminClient } from "../_lib";
 
 export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const user = await getUserFromAuthHeader(req);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const auth = await requireAal2(req);
+  if (!auth.ok) return auth.response;
+  const { user } = auth;
 
   const { id } = await params;
   if (!id) {
@@ -37,10 +37,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const user = await getUserFromAuthHeader(req);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const auth = await requireAal2(req);
+  if (!auth.ok) return auth.response;
+  const { user } = auth;
 
   const { id } = await params;
   if (!id) {

--- a/src/app/api/passkey/register/options/route.test.ts
+++ b/src/app/api/passkey/register/options/route.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  getUserFromAuthHeaderMock,
+  getAdminClientMock,
+  setChallengeCookieMock,
+  generateRegistrationOptionsMock,
+  getAalMock,
+  authRestListFactorsMock,
+  countSelectMock,
+} = vi.hoisted(() => ({
+  getUserFromAuthHeaderMock: vi.fn(),
+  getAdminClientMock: vi.fn(),
+  setChallengeCookieMock: vi.fn(),
+  generateRegistrationOptionsMock: vi.fn(),
+  getAalMock: vi.fn(),
+  authRestListFactorsMock: vi.fn(),
+  countSelectMock: vi.fn(),
+}));
+
+vi.mock("../../_lib", () => ({
+  RP_NAME: "Test",
+  getRpId: () => "test.local",
+  getUserFromAuthHeader: getUserFromAuthHeaderMock,
+  getAdminClient: getAdminClientMock,
+  setChallengeCookie: setChallengeCookieMock,
+}));
+vi.mock("@simplewebauthn/server", () => ({
+  generateRegistrationOptions: generateRegistrationOptionsMock,
+}));
+vi.mock("@/lib/auth/aal", () => ({ getAal: getAalMock }));
+vi.mock("@/lib/auth/supabase-rest", () => ({
+  authRestListFactors: authRestListFactorsMock,
+}));
+
+import { POST } from "./route";
+
+function makeReq(authHeader?: string, body?: unknown): NextRequest {
+  const headers = new Headers();
+  if (authHeader) headers.set("authorization", authHeader);
+  return new NextRequest("http://test.local/api/passkey/register/options", {
+    method: "POST",
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function adminWithExistingCount(count: number) {
+  // .from("user_passkeys").select("id", { count, head: true }).eq("user_id", x)
+  const countSelect = vi.fn();
+  countSelect.mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ count, error: null }),
+  });
+  // .from("user_passkeys").select("credential_id, transports").eq("user_id", x)
+  const credSelect = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+  });
+  // dynamic dispatch on first arg of select
+  const select = vi.fn((...args: unknown[]) => {
+    if (args[0] === "id") return countSelect();
+    return credSelect();
+  });
+  return {
+    from: vi.fn(() => ({ select })),
+  };
+}
+
+beforeEach(() => {
+  getUserFromAuthHeaderMock.mockReset();
+  getAdminClientMock.mockReset();
+  setChallengeCookieMock.mockReset();
+  generateRegistrationOptionsMock.mockReset();
+  getAalMock.mockReset();
+  authRestListFactorsMock.mockReset();
+  countSelectMock.mockReset();
+});
+
+describe("POST /api/passkey/register/options", () => {
+  it("returns 401 when not authenticated", async () => {
+    getUserFromAuthHeaderMock.mockResolvedValue(null);
+    const res = await POST(makeReq("Bearer bad"));
+    expect(res.status).toBe(401);
+    expect(generateRegistrationOptionsMock).not.toHaveBeenCalled();
+  });
+
+  it("(bootstrap) allows AAL1 when user has no existing factor", async () => {
+    getUserFromAuthHeaderMock.mockResolvedValue({
+      id: "u1",
+      email: "u@example.com",
+    });
+    getAdminClientMock.mockReturnValue(adminWithExistingCount(0));
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+      status: 200,
+    });
+    generateRegistrationOptionsMock.mockResolvedValue({
+      challenge: "ch",
+      rp: { id: "test.local", name: "Test" },
+      user: { id: "u1", name: "u@example.com", displayName: "U" },
+    });
+
+    const res = await POST(makeReq("Bearer good"));
+
+    expect(res.status).toBe(200);
+    expect(getAalMock).not.toHaveBeenCalled();
+    expect(generateRegistrationOptionsMock).toHaveBeenCalled();
+  });
+
+  it("(negative) requires AAL2 when user already has a passkey", async () => {
+    getUserFromAuthHeaderMock.mockResolvedValue({ id: "u1" });
+    getAdminClientMock.mockReturnValue(adminWithExistingCount(1));
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+      status: 200,
+    });
+    getAalMock.mockResolvedValue("aal1");
+
+    const res = await POST(makeReq("Bearer good"));
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("AAL2_REQUIRED");
+    expect(generateRegistrationOptionsMock).not.toHaveBeenCalled();
+  });
+
+  it("(negative) requires AAL2 when user has a verified Supabase factor", async () => {
+    getUserFromAuthHeaderMock.mockResolvedValue({ id: "u1" });
+    getAdminClientMock.mockReturnValue(adminWithExistingCount(0));
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [{ id: "f1", factor_type: "totp", status: "verified" }],
+      status: 200,
+    });
+    getAalMock.mockResolvedValue("aal1");
+
+    const res = await POST(makeReq("Bearer good"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("(positive) enrolls additional passkey at AAL2", async () => {
+    getUserFromAuthHeaderMock.mockResolvedValue({
+      id: "u1",
+      email: "u@example.com",
+    });
+    getAdminClientMock.mockReturnValue(adminWithExistingCount(1));
+    authRestListFactorsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+      status: 200,
+    });
+    getAalMock.mockResolvedValue("aal2");
+    generateRegistrationOptionsMock.mockResolvedValue({
+      challenge: "ch",
+      rp: { id: "test.local", name: "Test" },
+      user: { id: "u1", name: "u@example.com", displayName: "U" },
+    });
+
+    const res = await POST(makeReq("Bearer good"));
+
+    expect(res.status).toBe(200);
+    expect(generateRegistrationOptionsMock).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/passkey/register/options/route.ts
+++ b/src/app/api/passkey/register/options/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateRegistrationOptions } from "@simplewebauthn/server";
+import { getAal } from "@/lib/auth/aal";
+import { authRestListFactors } from "@/lib/auth/supabase-rest";
 import {
   RP_NAME,
   getRpId,
@@ -14,6 +16,37 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const authHeader = req.headers.get("authorization");
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : "";
+
+  const admin = getAdminClient();
+
+  // Bootstrap exception: a user enrolling their first verified factor (passkey
+  // or TOTP) is allowed at AAL1 — that's how MFA gets bootstrapped. Once any
+  // verified factor exists, adding another factor requires AAL2.
+  const { count: existingPasskeys } = await admin
+    .from("user_passkeys")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id);
+  const factorsResult = await authRestListFactors(token);
+  const hasVerifiedSupabaseFactor =
+    factorsResult.ok && factorsResult.data.some((f) => f.status === "verified");
+  const hasExistingFactor =
+    (existingPasskeys ?? 0) > 0 || hasVerifiedSupabaseFactor;
+
+  if (hasExistingFactor) {
+    const aal = await getAal(token);
+    if (aal !== "aal2") {
+      return NextResponse.json(
+        {
+          error: "Step-up required. Verify your second factor to continue.",
+          code: "AAL2_REQUIRED",
+        },
+        { status: 403 },
+      );
+    }
+  }
+
   // Best-effort: read the proposed name early so we can reject a duplicate
   // before kicking off the WebAuthn ceremony (otherwise the user does Touch
   // ID for nothing). Body is optional — old clients still work.
@@ -26,8 +59,6 @@ export async function POST(req: NextRequest) {
   } catch {
     // No body / invalid JSON — fall through to legacy behavior.
   }
-
-  const admin = getAdminClient();
 
   if (proposedName) {
     const { data: clash } = await admin

--- a/src/app/api/passkey/register/verify/route.ts
+++ b/src/app/api/passkey/register/verify/route.ts
@@ -3,6 +3,8 @@ import {
   verifyRegistrationResponse,
   type RegistrationResponseJSON,
 } from "@simplewebauthn/server";
+import { getAal } from "@/lib/auth/aal";
+import { authRestListFactors } from "@/lib/auth/supabase-rest";
 import {
   bytesToBase64Url,
   clearChallengeCookie,
@@ -22,6 +24,38 @@ export async function POST(req: NextRequest) {
   const user = await getUserFromAuthHeader(req);
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : "";
+
+  // Same bootstrap check as register/options. The verify step is gated even
+  // though options already gated, so a session that drops AAL between options
+  // and verify can't slip through. The cookie ties verify to the original user
+  // (cookie.userId === user.id below), but the AAL check confirms the live
+  // session state at verification time.
+  const admin = getAdminClient();
+  const { count: existingPasskeys } = await admin
+    .from("user_passkeys")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id);
+  const factorsResult = await authRestListFactors(token);
+  const hasVerifiedSupabaseFactor =
+    factorsResult.ok && factorsResult.data.some((f) => f.status === "verified");
+  const hasExistingFactor =
+    (existingPasskeys ?? 0) > 0 || hasVerifiedSupabaseFactor;
+
+  if (hasExistingFactor) {
+    const aal = await getAal(token);
+    if (aal !== "aal2") {
+      return NextResponse.json(
+        {
+          error: "Step-up required. Verify your second factor to continue.",
+          code: "AAL2_REQUIRED",
+        },
+        { status: 403 },
+      );
+    }
   }
 
   const cookie = readChallengeCookie(req);
@@ -80,7 +114,6 @@ export async function POST(req: NextRequest) {
 
   const { credential } = verification.registrationInfo;
 
-  const admin = getAdminClient();
   const { error } = await admin.from("user_passkeys").insert({
     user_id: user.id,
     credential_id: credential.id,

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse, NextRequest } from "next/server";
+import { getPostVerifyTarget } from "@/lib/auth/post-verify";
 
 const friendlyCallbackMessage = (message?: string | null) => {
   const normalized = (message || "").toLowerCase();
@@ -104,14 +105,9 @@ export async function GET(request: NextRequest) {
       }
       // Email verified — user now has an active session from verifyOtp.
       // Redirect through client-side page to signal original tab and proceed.
-      // Signup and magic-link verifications always land on /dashboard so a
-      // brand-new account sees the welcome state instead of being dumped
-      // into a fresh quiz; old email templates that bake `next=/content-
-      // selection` into the link can't override that intent.
-      const safeNext =
-        type === "signup" || type === "magiclink" || type === "email"
-          ? "/dashboard"
-          : next;
+      // Routing decision lives in lib/auth/post-verify so it's testable
+      // without standing up the route handler.
+      const safeNext = getPostVerifyTarget(type, next);
       const verifiedParams = new URLSearchParams({ next: safeNext });
       return NextResponse.redirect(
         `${origin}/auth/verified?${verifiedParams.toString()}`,

--- a/src/features/auth/services/auth-service.ts
+++ b/src/features/auth/services/auth-service.ts
@@ -345,11 +345,31 @@ class AuthService {
       if (!isValidEmail(normalizedEmail))
         return { error: "Please enter a valid email address." };
 
-      const { error: authError } = await supabase.auth.updateUser({
-        email: normalizedEmail,
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        return { error: "No active session. Please sign in again." };
+      }
+
+      const resp = await fetch("/api/account/email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ email: normalizedEmail }),
       });
-      if (authError)
-        return { error: toUserFriendlyError(authError.message) };
+      if (!resp.ok) {
+        const payload = (await resp.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        return {
+          error: toUserFriendlyError(
+            payload.error ?? "Failed to update email.",
+          ),
+        };
+      }
 
       const {
         data: { user },
@@ -374,8 +394,32 @@ class AuthService {
     try {
       if (password.length < 8)
         return { error: "Password must be at least 8 characters." };
-      const { error } = await supabase.auth.updateUser({ password });
-      if (error) return { error: toUserFriendlyError(error.message) };
+
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        return { error: "No active session. Please sign in again." };
+      }
+
+      const resp = await fetch("/api/account/password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ password }),
+      });
+      if (!resp.ok) {
+        const payload = (await resp.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        return {
+          error: toUserFriendlyError(
+            payload.error ?? "Failed to update password.",
+          ),
+        };
+      }
       return { error: null };
     } catch (err) {
       console.error("Unexpected error updating password:", err);

--- a/src/features/auth/services/mfa-service.ts
+++ b/src/features/auth/services/mfa-service.ts
@@ -45,22 +45,41 @@ class MfaService {
       });
       const label = `${trimmed || "Authenticator"} · ${datePart}`;
 
-      const { data, error } = await supabase.auth.mfa.enroll({
-        factorType: "totp",
-        friendlyName: label,
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        return { error: "No active session. Please sign in again.", data: null };
+      }
+
+      const resp = await fetch("/api/account/mfa/totp/enroll", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ friendlyName: label }),
       });
 
-      if (error) {
-        console.error("MFA enroll error:", error.message, error);
+      const payload = (await resp.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+        id?: string;
+        type?: string;
+        totp?: { qr_code?: string; secret?: string; uri?: string };
+      };
+
+      if (!resp.ok) {
         return {
           error: toUserFriendlyError(
-            error.message,
+            payload.error ?? "Failed to start MFA enrollment.",
             "Failed to start MFA enrollment. Please try again.",
           ),
           data: null,
         };
       }
 
+      const data = payload as MFAEnrollData;
       return this.finalizeEnroll(data, user.id);
     } catch (err) {
       console.error("Error enrolling MFA:", err);
@@ -127,8 +146,30 @@ class MfaService {
 
   async unenroll(factorId: string) {
     try {
-      const { error } = await supabase.auth.mfa.unenroll({ factorId });
-      if (error) return { error: toUserFriendlyError(error.message) };
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        return { error: "No active session. Please sign in again." };
+      }
+
+      const resp = await fetch(
+        `/api/account/mfa/factor/${encodeURIComponent(factorId)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        },
+      );
+      if (!resp.ok) {
+        const payload = (await resp.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        return {
+          error: toUserFriendlyError(
+            payload.error ?? "Failed to unenroll MFA factor.",
+          ),
+        };
+      }
 
       const {
         data: { user },
@@ -175,24 +216,40 @@ class MfaService {
     }
 
     try {
-      const { data, error } = await supabase.rpc("rename_mfa_factor", {
-        p_factor_id: factorId,
-        p_new_name: trimmed,
-      });
-
-      if (error) {
-        // Postgres unique-constraint violation surfaces as 23505. Supabase
-        // rejects duplicate friendly_names per user, so translate that to
-        // a plain English message.
-        if ((error as { code?: string }).code === "23505") {
-          return { error: "You already have an authenticator with that name." };
-        }
-        return { error: toUserFriendlyError(error.message) };
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        return { error: "No active session. Please sign in again." };
       }
 
-      // RPC returns FOUND — false means nothing matched (wrong id or not yours).
-      if (data === false) {
-        return { error: "Authenticator not found." };
+      const resp = await fetch(
+        `/api/account/mfa/factor/${encodeURIComponent(factorId)}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({ friendlyName: trimmed }),
+        },
+      );
+
+      if (!resp.ok) {
+        const payload = (await resp.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        if (resp.status === 409) {
+          return { error: "You already have an authenticator with that name." };
+        }
+        if (resp.status === 404) {
+          return { error: "Authenticator not found." };
+        }
+        return {
+          error: toUserFriendlyError(
+            payload.error ?? "Failed to rename authenticator.",
+          ),
+        };
       }
 
       return { error: null };

--- a/src/lib/auth/aal.test.ts
+++ b/src/lib/auth/aal.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getUserMock, getAALMock } = vi.hoisted(() => ({
+  getUserMock: vi.fn(),
+  getAALMock: vi.fn(),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: getUserMock,
+      mfa: { getAuthenticatorAssuranceLevel: getAALMock },
+    },
+  }),
+}));
+
+import { requireAal2, getAal } from "./aal";
+
+function makeReq(authHeader?: string): NextRequest {
+  const headers = new Headers();
+  if (authHeader) headers.set("authorization", authHeader);
+  return new NextRequest("http://test.local/x", { headers });
+}
+
+describe("getAal", () => {
+  beforeEach(() => {
+    getAALMock.mockReset();
+  });
+
+  it("returns aal2 when Supabase reports aal2", async () => {
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal2", nextLevel: "aal2" },
+      error: null,
+    });
+    expect(await getAal("token")).toBe("aal2");
+  });
+
+  it("returns aal1 when Supabase reports aal1", async () => {
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal1", nextLevel: "aal2" },
+      error: null,
+    });
+    expect(await getAal("token")).toBe("aal1");
+  });
+
+  it("treats null currentLevel as aal1", async () => {
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: null, nextLevel: "aal1" },
+      error: null,
+    });
+    expect(await getAal("token")).toBe("aal1");
+  });
+
+  it("returns null when Supabase reports an error", async () => {
+    getAALMock.mockResolvedValue({
+      data: null,
+      error: { message: "invalid token" },
+    });
+    expect(await getAal("token")).toBe(null);
+  });
+
+  it("returns null on thrown exception (fail closed)", async () => {
+    getAALMock.mockRejectedValue(new Error("network"));
+    expect(await getAal("token")).toBe(null);
+  });
+
+  it("returns null when token is empty", async () => {
+    expect(await getAal("")).toBe(null);
+    expect(getAALMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireAal2", () => {
+  beforeEach(() => {
+    getUserMock.mockReset();
+    getAALMock.mockReset();
+  });
+
+  it("returns 401 when no Authorization header is set", async () => {
+    const result = await requireAal2(makeReq());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(401);
+  });
+
+  it("returns 401 when Authorization is not a Bearer token", async () => {
+    const result = await requireAal2(makeReq("Basic abcd"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(401);
+  });
+
+  it("returns 401 when getUser returns no user", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: { message: "invalid" },
+    });
+    const result = await requireAal2(makeReq("Bearer xyz"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(401);
+  });
+
+  it("returns 403 with AAL2_REQUIRED when user is at aal1", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal1", nextLevel: "aal2" },
+      error: null,
+    });
+    const result = await requireAal2(makeReq("Bearer xyz"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(403);
+    const body = (await result.response.json()) as {
+      error: string;
+      code: string;
+    };
+    expect(body.code).toBe("AAL2_REQUIRED");
+  });
+
+  it("returns ok with user and token when at aal2", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1", email: "u@example.com" } },
+      error: null,
+    });
+    getAALMock.mockResolvedValue({
+      data: { currentLevel: "aal2", nextLevel: "aal2" },
+      error: null,
+    });
+    const result = await requireAal2(makeReq("Bearer xyz"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.user.id).toBe("u1");
+    expect(result.token).toBe("xyz");
+  });
+
+  it("fails closed (403) when AAL check returns an error", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "u1" } },
+      error: null,
+    });
+    getAALMock.mockResolvedValue({ data: null, error: { message: "x" } });
+    const result = await requireAal2(makeReq("Bearer xyz"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(403);
+  });
+});

--- a/src/lib/auth/aal.ts
+++ b/src/lib/auth/aal.ts
@@ -1,0 +1,105 @@
+import { createClient, type User } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from "next/server";
+
+export type AALevel = "aal1" | "aal2";
+
+function getEnv() {
+  return {
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+  };
+}
+
+/**
+ * Reads the AAL claim for the provided JWT.
+ *
+ * Returns "aal2" only when Supabase reports the session is at AAL2. Anything
+ * else (aal1, null, error) maps to "aal1" or null. Never trust client-passed
+ * AAL state — this re-validates against the auth server every call.
+ */
+export async function getAal(jwt: string): Promise<AALevel | null> {
+  if (!jwt) return null;
+  const { url, anonKey } = getEnv();
+  if (!url || !anonKey) return null;
+
+  const client = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  try {
+    const { data, error } =
+      await client.auth.mfa.getAuthenticatorAssuranceLevel(jwt);
+    if (error || !data) return null;
+    return data.currentLevel === "aal2" ? "aal2" : "aal1";
+  } catch {
+    return null;
+  }
+}
+
+export type RequireAal2Result =
+  | { ok: true; user: User; token: string }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Server-side guard for sensitive operations that require a verified second
+ * factor. Caller must immediately return `result.response` if `ok` is false.
+ *
+ *   - 401 Unauthorized when the bearer header is missing/malformed or the
+ *     token does not resolve to an authenticated user.
+ *   - 403 with `code: "AAL2_REQUIRED"` when the token is valid but the
+ *     session is at AAL1. Clients route to /auth?mfa_required=true.
+ *
+ * Uses getUser(token) and mfa.getAuthenticatorAssuranceLevel(token) — both
+ * validate. Never uses getSession() for authorization decisions.
+ */
+export async function requireAal2(
+  req: NextRequest,
+): Promise<RequireAal2Result> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+  const token = authHeader.slice(7);
+
+  const { url, anonKey } = getEnv();
+  if (!url || !anonKey) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Server configuration error." },
+        { status: 500 },
+      ),
+    };
+  }
+
+  const client = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: userData, error: userError } = await client.auth.getUser(token);
+  if (userError || !userData.user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const aal = await getAal(token);
+  if (aal !== "aal2") {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "Step-up required. Verify your second factor to continue.",
+          code: "AAL2_REQUIRED",
+        },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { ok: true, user: userData.user, token };
+}

--- a/src/lib/auth/post-verify.test.ts
+++ b/src/lib/auth/post-verify.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPostVerifyTarget,
+  getMfaSetupCompleteTarget,
+  getMfaSetupSkipTarget,
+} from "./post-verify";
+
+describe("getPostVerifyTarget", () => {
+  it("routes signup through MFA enrollment", () => {
+    expect(getPostVerifyTarget("signup", "/dashboard")).toBe(
+      "/account/mfa-setup?from=signup",
+    );
+  });
+
+  it("routes magiclink directly to /dashboard", () => {
+    expect(getPostVerifyTarget("magiclink", "/dashboard")).toBe("/dashboard");
+  });
+
+  it("routes plain email type directly to /dashboard", () => {
+    expect(getPostVerifyTarget("email", "/dashboard")).toBe("/dashboard");
+  });
+
+  it("falls back to caller-provided next for other types", () => {
+    expect(getPostVerifyTarget("other", "/somewhere")).toBe("/somewhere");
+  });
+});
+
+describe("getMfaSetupCompleteTarget", () => {
+  it("routes signup-flow completion to /dashboard", () => {
+    expect(getMfaSetupCompleteTarget("signup")).toBe("/dashboard");
+  });
+
+  it("routes default-flow completion to /account/security", () => {
+    expect(getMfaSetupCompleteTarget(null)).toBe("/account/security");
+    expect(getMfaSetupCompleteTarget("settings")).toBe("/account/security");
+  });
+});
+
+describe("getMfaSetupSkipTarget", () => {
+  it("always routes to /dashboard", () => {
+    expect(getMfaSetupSkipTarget()).toBe("/dashboard");
+  });
+});

--- a/src/lib/auth/post-verify.ts
+++ b/src/lib/auth/post-verify.ts
@@ -1,0 +1,37 @@
+/**
+ * Where the user lands after the OTP-verify step in /auth/callback.
+ *
+ * Brand-new signups go through /account/mfa-setup so the user can enroll
+ * a second factor before reaching the app. Magic-link and plain-email
+ * verifications skip that step — these belong to existing users who either
+ * already have a factor or have explicitly chosen not to. Other types
+ * (recovery, email_change) are routed elsewhere by their callers and never
+ * pass through this helper.
+ */
+export function getPostVerifyTarget(
+  type: string,
+  fallback: string,
+): string {
+  if (type === "signup") return "/account/mfa-setup?from=signup";
+  if (type === "magiclink" || type === "email") return "/dashboard";
+  return fallback;
+}
+
+/**
+ * Where /account/mfa-setup routes the user when they finish (or skip)
+ * enrollment. When ?from=signup, this is the post-verify enrollment step
+ * and both outcomes land in the app. Otherwise the page is being used to
+ * add a factor mid-flow from /settings or /account/security, so completing
+ * stays on the security surface.
+ */
+export function getMfaSetupCompleteTarget(from: string | null): string {
+  return from === "signup" ? "/dashboard" : "/account/security";
+}
+
+/**
+ * Where /account/mfa-setup routes when the user skips enrollment. Always
+ * /dashboard — skipping should never trap the user on the enrollment page.
+ */
+export function getMfaSetupSkipTarget(): string {
+  return "/dashboard";
+}

--- a/src/lib/auth/supabase-rest.ts
+++ b/src/lib/auth/supabase-rest.ts
@@ -1,0 +1,157 @@
+/**
+ * Direct Supabase REST helpers for API routes that authenticate via Bearer
+ * header. These bypass the auth-js client because its MFA / updateUser methods
+ * read from a local session that the API-route flow doesn't have.
+ *
+ * Each call forwards the user's JWT in Authorization, plus the apikey header
+ * Supabase requires. Server-side ownership is enforced by Supabase against
+ * the JWT subject — not by trusting any caller-supplied user id.
+ */
+
+function getEnv() {
+  return {
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+  };
+}
+
+export type RestResult<T> =
+  | { ok: true; data: T; status: number }
+  | { ok: false; error: { message: string }; status: number };
+
+async function restCall<T>(
+  path: string,
+  init: RequestInit,
+  jwt: string,
+): Promise<RestResult<T>> {
+  const { url, anonKey } = getEnv();
+  if (!url || !anonKey) {
+    return {
+      ok: false,
+      status: 500,
+      error: { message: "Server configuration error." },
+    };
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${url}${path}`, {
+      ...init,
+      headers: {
+        apikey: anonKey,
+        authorization: `Bearer ${jwt}`,
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      error: {
+        message: err instanceof Error ? err.message : "Network error",
+      },
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await resp.json();
+  } catch {
+    body = null;
+  }
+
+  if (!resp.ok) {
+    const errBody = body as
+      | { message?: string; error?: string; msg?: string }
+      | null;
+    return {
+      ok: false,
+      status: resp.status,
+      error: {
+        message:
+          errBody?.message ??
+          errBody?.error ??
+          errBody?.msg ??
+          resp.statusText,
+      },
+    };
+  }
+
+  return { ok: true, status: resp.status, data: body as T };
+}
+
+export type RawFactor = {
+  id: string;
+  factor_type: string;
+  status: "verified" | "unverified";
+  friendly_name?: string | null;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export async function authRestListFactors(
+  jwt: string,
+): Promise<RestResult<RawFactor[]>> {
+  return restCall<RawFactor[]>("/auth/v1/factors", { method: "GET" }, jwt);
+}
+
+export async function authRestEnrollTotp(
+  jwt: string,
+  friendlyName?: string,
+): Promise<
+  RestResult<{
+    id: string;
+    type: string;
+    totp?: { qr_code?: string; secret?: string; uri?: string };
+  }>
+> {
+  return restCall(
+    "/auth/v1/factors",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        factor_type: "totp",
+        friendly_name: friendlyName,
+      }),
+    },
+    jwt,
+  );
+}
+
+export async function authRestUnenrollFactor(
+  jwt: string,
+  factorId: string,
+): Promise<RestResult<unknown>> {
+  return restCall(
+    `/auth/v1/factors/${encodeURIComponent(factorId)}`,
+    { method: "DELETE" },
+    jwt,
+  );
+}
+
+export async function authRestUpdateUser(
+  jwt: string,
+  payload: { email?: string; password?: string },
+): Promise<RestResult<unknown>> {
+  return restCall(
+    "/auth/v1/user",
+    { method: "PUT", body: JSON.stringify(payload) },
+    jwt,
+  );
+}
+
+export async function rpcRestRenameFactor(
+  jwt: string,
+  factorId: string,
+  newName: string,
+): Promise<RestResult<boolean>> {
+  return restCall<boolean>(
+    "/rest/v1/rpc/rename_mfa_factor",
+    {
+      method: "POST",
+      body: JSON.stringify({ p_factor_id: factorId, p_new_name: newName }),
+    },
+    jwt,
+  );
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ||= "https://test.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ||= "test-service-key";


### PR DESCRIPTION
## Summary
- Adds a server-enforced AAL2 (Authenticator Assurance Level 2) gate via `lib/auth/aal.ts`. AAL2 stops being a UI flow and becomes a real authorization level: callers without a verified second factor are rejected at the route boundary with `403 { code: "AAL2_REQUIRED" }`.
- Wraps every sensitive operation behind that gate: account delete, account disable, factor add/rename/delete (TOTP and passkey), email change, password change. New API routes were added where none existed (`/api/account/email`, `/api/account/password`, `/api/account/mfa/totp/enroll`, `/api/account/mfa/factor/[id]`); the client services were migrated to call them instead of `supabase.auth.*` directly.
- Bootstrap exception is server-side: a user enrolling their first verified factor (TOTP or passkey) is allowed at AAL1 — that's how MFA gets bootstrapped. Once any verified factor exists, adding another factor or managing an existing one requires AAL2. The check reads from sources Supabase or the user owns directly, not from the public `mfa_factors` mirror.
- Routes a fresh signup through `/account/mfa-setup` between email verification and `/dashboard`. The page already existed but was unreachable from the navigation graph; both completing and skipping enrollment now land in the app via shared helpers in `lib/auth/post-verify.ts`.

## Files changed
27 files, +2094 / -95. 11 commits. Routing decisions and AAL helpers extracted to `src/lib/auth/` so they're testable without standing up route handlers.

## Test plan
- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `npm test` — 75 passing across 12 files (baseline: 13 across 2)
- [x] Negative tests fail closed: every gated operation rejects an AAL1 caller with a `403 AAL2_REQUIRED` and never invokes the underlying Supabase admin call. Verified for `/account/delete`, `/account/disable`, `/account/email`, `/account/password`, TOTP enroll/rename/delete, passkey rename/delete, passkey-enroll bootstrap.
- [x] Bootstrap-exception positives: TOTP and passkey enroll succeed at AAL1 only when the user has zero verified factors. Verified across both routes' tests.
- [x] Signup → MFA enrollment → dashboard routing is wired and tested at the helper layer.
- [ ] Manual smoke (Andrew): sign up fresh → verify email → land on `/account/mfa-setup` → enroll → reach `/dashboard`. Repeat with skip.
- [ ] Manual smoke: existing AAL1 user attempting `/account/delete` is rejected with 403; existing AAL2 user can complete the operation.

## Notes for review
- The password-reset (post-recovery-email) flow at `account-service.updatePasswordWithTicket` intentionally stays on `supabase.auth.updateUser` direct — the recovery session has no AAL2 to verify, and gating it would lock recovery out of the account.
- Some fix shapes that were originally in the spec turned out impossible against the installed Supabase versions (e.g., `auth.admin.createSession` does not exist) and are out of Phase 0 scope; the contract's later phases address them differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)