### PR TITLE
feat(web,db): profiles_public view + dedicated report screen replaces window.prompt

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
+import nextPlugin from "@next/eslint-plugin-next";
 import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
 
@@ -28,9 +29,16 @@ export default tseslint.config(
       globals: { ...globals.browser, ...globals.node },
     },
     plugins: {
+      // The @next/next plugin is registered so the rule names that
+      // the codebase's `// eslint-disable-next-line @next/next/...`
+      // comments reference are defined — without this, ESLint 9 flat
+      // config errors with "Definition for rule '@next/next/...' was
+      // not found" on every disable directive that targets one.
+      "@next/next": nextPlugin,
       "react-hooks": reactHooks,
     },
     rules: {
+      ...nextPlugin.configs["core-web-vitals"].rules,
       ...reactHooks.configs.recommended.rules,
       "no-undef": "off",
       "no-unused-vars": "off",

--- a/messages/de.json
+++ b/messages/de.json
@@ -50,7 +50,9 @@
         "onPost": "Bei einem Beitrag",
         "onComment": "Bei einem Kommentar",
         "contentGone": "Inhalt entfernt",
-        "statusReview": "In Prüfung"
+        "statusReview": "In Prüfung",
+        "statusReviewed": "Geprüft",
+        "statusDismissed": "Verworfen"
       }
     },
     "groups": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -8,6 +8,7 @@
       "security": "Sicherheit",
       "content": "Inhalt",
       "feed": "Feed",
+      "notifications": "Benachrichtigungen",
       "integrations": "Integrationen",
       "help": "Hilfe"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -50,7 +50,9 @@
         "onPost": "On a post",
         "onComment": "On a comment",
         "contentGone": "Content removed",
-        "statusReview": "Under review"
+        "statusReview": "Under review",
+        "statusReviewed": "Reviewed",
+        "statusDismissed": "Dismissed"
       }
     },
     "groups": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,6 +8,7 @@
       "security": "Security",
       "content": "Content",
       "feed": "Feed",
+      "notifications": "Notifications",
       "integrations": "Integrations",
       "help": "Help"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -50,7 +50,9 @@
         "onPost": "En una publicación",
         "onComment": "En un comentario",
         "contentGone": "Contenido eliminado",
-        "statusReview": "En revisión"
+        "statusReview": "En revisión",
+        "statusReviewed": "Revisado",
+        "statusDismissed": "Descartado"
       }
     },
     "groups": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,6 +8,7 @@
       "security": "Seguridad",
       "content": "Contenido",
       "feed": "Feed",
+      "notifications": "Notificaciones",
       "integrations": "Integraciones",
       "help": "Ayuda"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8,6 +8,7 @@
       "security": "Sécurité",
       "content": "Contenu",
       "feed": "Fil",
+      "notifications": "Notifications",
       "integrations": "Intégrations",
       "help": "Aide"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -50,7 +50,9 @@
         "onPost": "Sur une publication",
         "onComment": "Sur un commentaire",
         "contentGone": "Contenu supprimé",
-        "statusReview": "En cours d'examen"
+        "statusReview": "En cours d'examen",
+        "statusReviewed": "Examiné",
+        "statusDismissed": "Rejeté"
       }
     },
     "groups": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -50,7 +50,9 @@
         "onPost": "Su un post",
         "onComment": "Su un commento",
         "contentGone": "Contenuto rimosso",
-        "statusReview": "In revisione"
+        "statusReview": "In revisione",
+        "statusReviewed": "Revisionato",
+        "statusDismissed": "Respinto"
       }
     },
     "groups": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -8,6 +8,7 @@
       "security": "Sicurezza",
       "content": "Contenuto",
       "feed": "Feed",
+      "notifications": "Notifiche",
       "integrations": "Integrazioni",
       "help": "Aiuto"
     },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -50,7 +50,9 @@
         "onPost": "投稿に対して",
         "onComment": "コメントに対して",
         "contentGone": "コンテンツは削除されました",
-        "statusReview": "確認中"
+        "statusReview": "確認中",
+        "statusReviewed": "確認済み",
+        "statusDismissed": "却下"
       }
     },
     "groups": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -8,6 +8,7 @@
       "security": "セキュリティ",
       "content": "コンテンツ",
       "feed": "フィード",
+      "notifications": "通知",
       "integrations": "連携",
       "help": "ヘルプ"
     },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -8,6 +8,7 @@
       "security": "보안",
       "content": "콘텐츠",
       "feed": "피드",
+      "notifications": "알림",
       "integrations": "연동",
       "help": "도움말"
     },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -50,7 +50,9 @@
         "onPost": "게시물에 대해",
         "onComment": "댓글에 대해",
         "contentGone": "콘텐츠가 삭제됨",
-        "statusReview": "검토 중"
+        "statusReview": "검토 중",
+        "statusReviewed": "검토됨",
+        "statusDismissed": "기각됨"
       }
     },
     "groups": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -50,7 +50,9 @@
         "onPost": "Bij een bericht",
         "onComment": "Bij een reactie",
         "contentGone": "Inhoud verwijderd",
-        "statusReview": "In behandeling"
+        "statusReview": "In behandeling",
+        "statusReviewed": "Beoordeeld",
+        "statusDismissed": "Afgewezen"
       }
     },
     "groups": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -8,6 +8,7 @@
       "security": "Beveiliging",
       "content": "Inhoud",
       "feed": "Feed",
+      "notifications": "Meldingen",
       "integrations": "Integraties",
       "help": "Help"
     },

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -8,6 +8,7 @@
       "security": "Segurança",
       "content": "Conteúdo",
       "feed": "Feed",
+      "notifications": "Notificações",
       "integrations": "Integrações",
       "help": "Ajuda"
     },

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -50,7 +50,9 @@
         "onPost": "Em uma publicação",
         "onComment": "Em um comentário",
         "contentGone": "Conteúdo removido",
-        "statusReview": "Em análise"
+        "statusReview": "Em análise",
+        "statusReviewed": "Analisado",
+        "statusDismissed": "Rejeitado"
       }
     },
     "groups": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -50,7 +50,9 @@
         "onPost": "对一个帖子",
         "onComment": "对一条评论",
         "contentGone": "内容已删除",
-        "statusReview": "审核中"
+        "statusReview": "审核中",
+        "statusReviewed": "已审核",
+        "statusDismissed": "已驳回"
       }
     },
     "groups": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -8,6 +8,7 @@
       "security": "安全",
       "content": "内容",
       "feed": "动态",
+      "notifications": "通知",
       "integrations": "集成",
       "help": "帮助"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@next/eslint-plugin-next": "^16.2.6",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1210,6 +1211,46 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
       "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "16.2.6",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@next/eslint-plugin-next": "^16.2.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -82,16 +82,19 @@ export default function AdminReportsPage() {
           active={filter === "open"}
           onClick={() => setFilter("open")}
           label={`Open · ${counts.open}`}
+          tone="amber"
         />
         <FilterChip
           active={filter === "resolved"}
           onClick={() => setFilter("resolved")}
           label={`Resolved · ${counts.resolved}`}
+          tone="emerald"
         />
         <FilterChip
           active={filter === "all"}
           onClick={() => setFilter("all")}
           label={`All · ${counts.all}`}
+          tone="slate"
         />
       </div>
 
@@ -123,24 +126,55 @@ export default function AdminReportsPage() {
   );
 }
 
+/** Pills carry the status semantic — Open is the same amber as the
+ *  Open status badge below, Resolved matches the emerald Reviewed
+ *  badge, All stays neutral slate so it doesn't compete with the
+ *  status-bearing options for visual weight. */
+type ChipTone = "amber" | "emerald" | "slate";
+
+const CHIP_TONES: Record<
+  ChipTone,
+  { active: string; inactive: string }
+> = {
+  amber: {
+    active:
+      "border-amber-500 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    inactive:
+      "border-slate-300 bg-slate-50 text-slate-600 hover:border-amber-300 hover:bg-amber-50/40 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300 dark:hover:border-amber-500/60 dark:hover:bg-amber-500/10",
+  },
+  emerald: {
+    active:
+      "border-emerald-500 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    inactive:
+      "border-slate-300 bg-slate-50 text-slate-600 hover:border-emerald-300 hover:bg-emerald-50/40 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300 dark:hover:border-emerald-500/60 dark:hover:bg-emerald-500/10",
+  },
+  slate: {
+    active:
+      "border-slate-500 bg-slate-500/10 text-slate-700 dark:text-slate-200",
+    inactive:
+      "border-slate-300 bg-slate-50 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300 dark:hover:bg-slate-800",
+  },
+};
+
 function FilterChip({
   active,
   onClick,
   label,
+  tone,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
+  tone: ChipTone;
 }) {
+  const t = CHIP_TONES[tone];
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
         "rounded-full border px-3.5 py-1.5 text-xs font-bold tracking-tight transition-colors",
-        active
-          ? "border-violet-500 bg-violet-500/10 text-violet-600 dark:text-violet-300"
-          : "border-slate-300 bg-slate-50 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300 dark:hover:bg-slate-800",
+        active ? t.active : t.inactive,
       )}
     >
       {label}

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { Check, ExternalLink, Flag, RotateCcw, X } from "lucide-react";
+import { toast } from "sonner";
+
+import { useAllReports, useSetReportStatus } from "@/features/feed/use-feed";
+import type {
+  AdminReport,
+  ReportStatus,
+} from "@/features/feed/feed-service";
+import { cn } from "@/lib/utils";
+
+type Filter = "open" | "resolved" | "all";
+
+/**
+ * /admin/reports — staff-only moderation queue for user-filed reports
+ * on posts and comments. Read visibility is gated server-side by the
+ * `feed_reports_select_admin` RLS policy (profiles.is_admin = TRUE);
+ * status changes are gated by `feed_reports_update_admin`. Non-admins
+ * who hit this URL directly just see the empty state because the
+ * query returns no rows for them.
+ */
+export default function AdminReportsPage() {
+  const { data, isLoading, error } = useAllReports();
+  const setStatus = useSetReportStatus();
+  const [filter, setFilter] = useState<Filter>("open");
+
+  const reports = useMemo(() => data ?? [], [data]);
+  const counts = useMemo(() => {
+    let open = 0;
+    let resolved = 0;
+    for (const r of reports) {
+      if (r.status === "open") open++;
+      else resolved++;
+    }
+    return { open, resolved, all: reports.length };
+  }, [reports]);
+
+  const visible = useMemo(() => {
+    return reports.filter((r) => {
+      if (filter === "open") return r.status === "open";
+      if (filter === "resolved") return r.status !== "open";
+      return true;
+    });
+  }, [reports, filter]);
+
+  const onSetStatus = (reportId: string, status: ReportStatus) => {
+    setStatus.mutate(
+      { reportId, status },
+      {
+        onSuccess: () =>
+          toast.success(
+            status === "reviewed"
+              ? "Marked reviewed"
+              : status === "dismissed"
+                ? "Dismissed"
+                : "Reopened",
+          ),
+        onError: () => toast.error("Couldn't update the report — try again."),
+      },
+    );
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <div className="mb-2 flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <Flag size={14} aria-hidden />
+        Admin
+      </div>
+      <h1 className="text-2xl font-black tracking-tight text-slate-900 dark:text-slate-50">
+        Reports
+      </h1>
+      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        User-filed reports on posts and comments. Mark each one reviewed
+        once you&rsquo;ve taken action, or dismiss if no action is needed.
+      </p>
+
+      <div className="mt-6 flex flex-wrap gap-2">
+        <FilterChip
+          active={filter === "open"}
+          onClick={() => setFilter("open")}
+          label={`Open · ${counts.open}`}
+        />
+        <FilterChip
+          active={filter === "resolved"}
+          onClick={() => setFilter("resolved")}
+          label={`Resolved · ${counts.resolved}`}
+        />
+        <FilterChip
+          active={filter === "all"}
+          onClick={() => setFilter("all")}
+          label={`All · ${counts.all}`}
+        />
+      </div>
+
+      <div className="mt-6 space-y-3">
+        {isLoading ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Loading reports…
+          </p>
+        ) : error ? (
+          <p className="rounded-xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-300">
+            Couldn&rsquo;t load reports.
+          </p>
+        ) : visible.length === 0 ? (
+          <p className="rounded-2xl border border-dashed border-slate-300/80 bg-slate-50/50 py-10 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:bg-slate-900/30 dark:text-slate-400">
+            {filter === "open" ? "No open reports." : "No reports here."}
+          </p>
+        ) : (
+          visible.map((r) => (
+            <ReportCard
+              key={r.id}
+              report={r}
+              onSetStatus={onSetStatus}
+              pending={setStatus.isPending}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-3.5 py-1.5 text-xs font-bold tracking-tight transition-colors",
+        active
+          ? "border-violet-500 bg-violet-500/10 text-violet-600 dark:text-violet-300"
+          : "border-slate-300 bg-slate-50 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300 dark:hover:bg-slate-800",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function ReportCard({
+  report,
+  onSetStatus,
+  pending,
+}: {
+  report: AdminReport;
+  onSetStatus: (id: string, status: ReportStatus) => void;
+  pending: boolean;
+}) {
+  const navHref =
+    report.target === "post"
+      ? report.postId
+        ? `/feed/${report.postId}`
+        : null
+      : report.commentPostId
+        ? `/feed/${report.commentPostId}`
+        : null;
+  const resolved = report.status !== "open";
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-slate-200 bg-white p-4 transition-opacity dark:border-slate-700 dark:bg-slate-900/60",
+        resolved && "opacity-65",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "rounded-full px-2 py-0.5 text-[10px] font-black uppercase tracking-wide",
+            report.target === "post"
+              ? "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+              : "bg-violet-500/15 text-violet-600 dark:text-violet-300",
+          )}
+        >
+          {report.target}
+        </span>
+        <StatusBadge status={report.status} />
+        <span className="ml-auto text-xs text-slate-400">
+          {ago(report.createdAt)}
+        </span>
+      </div>
+
+      <p className="mt-3 text-sm font-bold text-slate-800 dark:text-slate-100 line-clamp-3">
+        {report.targetLabel?.trim() || "(deleted)"}
+      </p>
+      {report.targetAuthorUsername || report.targetAuthorName ? (
+        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+          by @{report.targetAuthorUsername ?? report.targetAuthorName}
+        </p>
+      ) : null}
+
+      <div className="mt-3 flex items-start gap-2 text-xs">
+        <Flag
+          size={13}
+          className="mt-0.5 shrink-0 text-slate-400"
+          aria-hidden
+        />
+        <span className="flex-1 font-semibold text-slate-700 dark:text-slate-200">
+          {report.reason?.trim() || "no reason"}
+        </span>
+        {(report.reporterUsername || report.reporterName) && (
+          <span className="text-slate-400">
+            — @{report.reporterUsername ?? report.reporterName}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        {navHref && (
+          <Link
+            href={navHref}
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-bold text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            <ExternalLink size={12} />
+            Open {report.target === "post" ? "post" : "thread"}
+          </Link>
+        )}
+        {report.status === "open" ? (
+          <>
+            <button
+              type="button"
+              disabled={pending}
+              onClick={() => onSetStatus(report.id, "reviewed")}
+              className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1.5 text-xs font-bold text-emerald-700 transition-colors hover:bg-emerald-500/15 disabled:opacity-60 dark:bg-emerald-400/15 dark:text-emerald-300"
+            >
+              <Check size={12} />
+              Reviewed
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              onClick={() => onSetStatus(report.id, "dismissed")}
+              className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:opacity-60 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            >
+              <X size={12} />
+              Dismiss
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSetStatus(report.id, "open")}
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:opacity-60 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <RotateCcw size={12} />
+            Reopen
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: ReportStatus }) {
+  if (status === "reviewed") {
+    return (
+      <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-700 dark:bg-emerald-400/15 dark:text-emerald-300">
+        Reviewed
+      </span>
+    );
+  }
+  if (status === "dismissed") {
+    return (
+      <span className="rounded-full bg-slate-500/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-slate-600 dark:bg-slate-400/15 dark:text-slate-300">
+        Dismissed
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-amber-700 dark:text-amber-300">
+      Open
+    </span>
+  );
+}
+
+function ago(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return `${Math.floor(d / 30)}mo ago`;
+}

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { motion } from "motion/react";
+import { ArrowLeft, ChevronDown } from "lucide-react";
+
+import { AppNavbar } from "@/components/app-navbar";
+import { cn } from "@/lib/utils";
+
+/** In-app "What's new" — abridged per-batch notes for the web app.
+ *  Linked from Settings → Help → What's new. Web doesn't ship versioned
+ *  prereleases the way the mobile app does (no APK builds, no version
+ *  codes), so entries here are date-stamped feature batches rather
+ *  than `test.N` builds. */
+interface Release {
+  label: string;
+  date: string;
+  headline: string;
+  bullets: string[];
+}
+
+const RELEASES: Release[] = [
+  {
+    label: "May 24, 2026",
+    date: "May 24, 2026",
+    headline: "@mention links and emoji reactions across feed + threads.",
+    bullets: [
+      "@username spans in post bodies + comments — tap to open that profile.",
+      "Emoji reactions (❤️ 🔥 😂 😢 🤔 👏) on every post + every comment.",
+      "Reaction picker is a single trailing + button so the strip stays compact.",
+    ],
+  },
+  {
+    label: "May 23, 2026",
+    date: "May 23, 2026",
+    headline:
+      "Notifications bell, per-kind activity toggles, admin reports moderation.",
+    bullets: [
+      "Server notifications: followers, friend posts, comments, replies, post + comment upvotes.",
+      "Per-kind activity toggles under Settings → Notifications (mute follows, mute friend-posts, etc).",
+      "Admin Reports page (gated on profiles.is_admin) with open / reviewed / dismissed status chips.",
+      "Public report status visible to the original reporter on Settings → Filed reports.",
+      "Block flow gained a confirm dialog; blocked-people list scales with search above six entries.",
+    ],
+  },
+  {
+    label: "May 22, 2026",
+    date: "May 22, 2026",
+    headline:
+      "Server-backed feed parity with mobile + profiles_public view.",
+    bullets: [
+      "Feed now reads from profiles_public so author display names hydrate across accounts.",
+      "Dedicated report screen replaces the old window.prompt confirm.",
+      "Reports moderation status (open / reviewed / dismissed) added to the schema.",
+      "Followee-delete cascade so a deleted account doesn't leave dangling follows.",
+    ],
+  },
+  {
+    label: "May 21, 2026",
+    date: "May 21, 2026",
+    headline:
+      "Feed sort (trending / new / top), clickable tags, eight new locales.",
+    bullets: [
+      "Trending / New / Top sort axis on top of the scope filter.",
+      "Clickable r/community tags drill the feed into a single content lane.",
+      "Edit-from-thread: open the composer directly from the post detail menu.",
+      "UI translated into French, German, Portuguese, Italian, Dutch, Japanese, Chinese, and Korean.",
+      "FAQ gained a Feed category with six questions covering the new UX.",
+    ],
+  },
+  {
+    label: "May 20, 2026",
+    date: "May 20, 2026",
+    headline:
+      "Composer polish: live preview, cover-art lookup, focus retention.",
+    bullets: [
+      "Live preview in the composer before posting or editing.",
+      "Cover lookup overwrites year and autofills director / creator metadata.",
+      "Composer input keeps focus through the autocomplete loop.",
+      "Confirm before discarding an unsaved pick.",
+      "Post votes, comment edit, delete, share, and reporting all wired.",
+    ],
+  },
+];
+
+export default function ChangelogPage() {
+  const router = useRouter();
+  // First entry expanded by default — most recent build is visible
+  // without a tap (same convention as the mobile in-app changelog).
+  const [openIdx, setOpenIdx] = useState(0);
+
+  return (
+    <div className="min-h-screen w-full bg-slate-50 text-slate-900 antialiased transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+      <AppNavbar />
+      <main className="px-4 pb-20 pt-28 sm:px-6 md:pt-36">
+        <div className="mx-auto w-full max-w-3xl">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="group mb-6 inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-bold tracking-tight text-slate-700 shadow-sm backdrop-blur-md transition-all duration-200 hover:-translate-x-0.5 hover:border-slate-300 hover:bg-white sm:text-sm dark:border-slate-700/70 dark:bg-slate-900/65 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-800/70"
+          >
+            <ArrowLeft
+              size={14}
+              className="transition-transform duration-200 group-hover:-translate-x-0.5"
+            />
+            Back
+          </button>
+
+          <div className="mb-8">
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
+              Updates
+            </p>
+            <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl lg:text-5xl">
+              What's new
+            </h1>
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+              Recent feature drops, newest first. Tap a date to expand
+              the highlights.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            {RELEASES.map((r, i) => {
+              const isOpen = openIdx === i;
+              return (
+                <motion.div
+                  key={r.date}
+                  layout
+                  className="overflow-hidden rounded-3xl border border-slate-200/70 bg-white/85 shadow-sm backdrop-blur-md dark:border-slate-700/60 dark:bg-slate-900/65"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setOpenIdx(isOpen ? -1 : i)}
+                    aria-expanded={isOpen}
+                    className="flex w-full items-start justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-slate-50/60 dark:hover:bg-slate-800/40"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[11px] font-bold uppercase tracking-[0.15em] text-slate-400 dark:text-slate-500">
+                        {r.label}
+                      </p>
+                      <p className="mt-1 text-sm font-bold leading-snug text-slate-800 dark:text-slate-100">
+                        {r.headline}
+                      </p>
+                    </div>
+                    <ChevronDown
+                      size={18}
+                      className={cn(
+                        "mt-1 shrink-0 text-slate-400 transition-transform duration-200",
+                        isOpen && "rotate-180 text-indigo-500",
+                      )}
+                    />
+                  </button>
+                  {isOpen && (
+                    <motion.ul
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.16 }}
+                      className="space-y-2 px-5 pb-5 text-[13px] leading-relaxed text-slate-600 dark:text-slate-300"
+                    >
+                      {r.bullets.map((b, j) => (
+                        <li key={j} className="flex gap-2">
+                          <span
+                            aria-hidden
+                            className="mt-1.5 inline-block h-1 w-1 shrink-0 rounded-full bg-slate-400 dark:bg-slate-500"
+                          />
+                          <span>{b}</span>
+                        </li>
+                      ))}
+                    </motion.ul>
+                  )}
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 import { AlertTriangle, RefreshCw, Home } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -49,13 +50,13 @@ export default function GlobalError({
         )}
 
         <div className="mt-8 flex w-full flex-col-reverse gap-3 sm:flex-row sm:justify-center">
-          <a
+          <Link
             href="/"
             className="inline-flex h-11 items-center justify-center gap-2 rounded-full border border-slate-200/80 bg-white/80 px-6 text-sm font-bold tracking-tight text-slate-700 backdrop-blur-md transition hover:border-slate-300 hover:bg-white dark:border-slate-700/70 dark:bg-slate-900/65 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-800/70"
           >
             <Home size={16} />
             {t("goHome")}
-          </a>
+          </Link>
           <button
             onClick={reset}
             className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-violet-500/10 px-6 text-sm font-bold tracking-tight text-violet-600 transition hover:bg-violet-500/15 dark:bg-violet-400/15 dark:text-violet-300 dark:hover:bg-violet-400/20"

--- a/src/app/feed/[id]/page.tsx
+++ b/src/app/feed/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   useDeleteComment,
   useMyCommentVotes,
   useMyPostVotes,
+  useReactions,
   useSaved,
   useSetCommentVote,
   useSetPostVote,
@@ -41,6 +42,8 @@ import { FeedAvatar } from "@/features/feed/components/feed-avatar";
 import { BlockMenuButton } from "@/features/feed/components/block-menu";
 import { MentionText } from "@/features/feed/mention-text";
 import { PostMenuButton } from "@/features/feed/components/post-menu";
+import { ReactionBar } from "@/features/feed/reaction-bar";
+import type { ReactionAggregates } from "@/features/feed/feed-service";
 import { useFeedPrefs } from "@/features/feed/use-feed-prefs";
 import {
   activityLabel,
@@ -57,10 +60,12 @@ function CommentNode({
   node,
   postId,
   depth,
+  reactions,
 }: {
   node: FeedCommentNode;
   postId: string;
   depth: number;
+  reactions: ReactionAggregates;
 }) {
   const router = useRouter();
   const setCommentVote = useSetCommentVote();
@@ -237,6 +242,12 @@ function CommentNode({
             <p className="mt-1.5 text-[13px] leading-relaxed text-slate-700 dark:text-slate-200">
               <MentionText body={node.body} />
             </p>
+            <ReactionBar
+              targetKind="comment"
+              targetId={node.id}
+              counts={reactions.counts[node.id] ?? {}}
+              mine={reactions.mine[node.id] ?? null}
+            />
             <button
               type="button"
               onClick={() => setReplying((r) => !r)}
@@ -345,6 +356,7 @@ function CommentNode({
                 node={child}
                 postId={postId}
                 depth={depth + 1}
+                reactions={reactions}
               />
             ))}
           </div>
@@ -387,6 +399,22 @@ export default function FeedThreadPage() {
     () => (post ? buildCommentTree(post.comments, commentSort) : []),
     [post, commentSort],
   );
+
+  // Single batched reactions query for the post + every comment on
+  // the page — collapses into one round-trip per kind so adding a
+  // hundred-comment thread stays cheap.
+  const commentIds = useMemo(
+    () => (post ? post.comments.map((c) => c.id) : []),
+    [post],
+  );
+  const { data: reactions } = useReactions({
+    postIds: post ? [post.id] : [],
+    commentIds,
+  });
+  const reactionsView: ReactionAggregates = reactions ?? {
+    counts: {},
+    mine: {},
+  };
 
   if (!ready) return <PageLoader text="Loading" />;
 
@@ -525,6 +553,13 @@ export default function FeedThreadPage() {
           </p>
         )}
 
+        <ReactionBar
+          targetKind="post"
+          targetId={post.id}
+          counts={reactionsView.counts[post.id] ?? {}}
+          mine={reactionsView.mine[post.id] ?? null}
+        />
+
         <div className="mt-4 flex items-center gap-4 border-t border-slate-200/70 pt-3 dark:border-slate-700/60">
           <div className="inline-flex items-center gap-1">
             <button
@@ -635,6 +670,7 @@ export default function FeedThreadPage() {
               node={node}
               postId={post.id}
               depth={0}
+              reactions={reactionsView}
             />
           ))
         )}

--- a/src/app/feed/[id]/page.tsx
+++ b/src/app/feed/[id]/page.tsx
@@ -29,7 +29,6 @@ import {
   useDeleteComment,
   useMyCommentVotes,
   useMyPostVotes,
-  useReportComment,
   useSaved,
   useSetCommentVote,
   useSetPostVote,
@@ -62,12 +61,12 @@ function CommentNode({
   postId: string;
   depth: number;
 }) {
+  const router = useRouter();
   const setCommentVote = useSetCommentVote();
   const { data: myVotes } = useMyCommentVotes();
   const createComment = useCreateComment();
   const deleteComment = useDeleteComment();
   const updateComment = useUpdateComment();
-  const reportComment = useReportComment();
   const { user } = useAuth();
   const isOwnComment =
     node.authorId != null && node.authorId === user?.id;
@@ -280,25 +279,11 @@ function CommentNode({
             ) : (
               <button
                 type="button"
-                onClick={() => {
-                  const reason = window.prompt(
-                    "Report this comment? Optionally tell us what's wrong:",
-                  );
-                  if (reason === null) return;
-                  reportComment.mutate(
-                    { commentId: node.id, reason: reason || undefined },
-                    {
-                      onSuccess: () =>
-                        toast.success(
-                          "Report submitted — thanks for flagging it.",
-                        ),
-                      onError: () =>
-                        toast.error(
-                          "Couldn't submit the report — try again.",
-                        ),
-                    },
-                  );
-                }}
+                onClick={() =>
+                  router.push(
+                    `/feed/report?commentId=${encodeURIComponent(node.id)}`,
+                  )
+                }
                 className="ml-3 mt-2 inline-flex items-center gap-1 text-[11px] font-bold text-slate-400 hover:text-amber-600 dark:hover:text-amber-300"
               >
                 <Flag size={12} /> Report

--- a/src/app/feed/[id]/page.tsx
+++ b/src/app/feed/[id]/page.tsx
@@ -279,11 +279,17 @@ function CommentNode({
             ) : (
               <button
                 type="button"
-                onClick={() =>
-                  router.push(
-                    `/feed/report?commentId=${encodeURIComponent(node.id)}`,
-                  )
-                }
+                onClick={() => {
+                  // Carry the comment author through so the report page
+                  // can offer an "Also block @author" toggle without
+                  // re-fetching.
+                  const qs = new URLSearchParams({
+                    commentId: node.id,
+                    ...(node.authorId ? { authorId: node.authorId } : {}),
+                    ...(node.author ? { author: node.author } : {}),
+                  }).toString();
+                  router.push(`/feed/report?${qs}`);
+                }}
                 className="ml-3 mt-2 inline-flex items-center gap-1 text-[11px] font-bold text-slate-400 hover:text-amber-600 dark:hover:text-amber-300"
               >
                 <Flag size={12} /> Report

--- a/src/app/feed/[id]/page.tsx
+++ b/src/app/feed/[id]/page.tsx
@@ -39,6 +39,7 @@ import {
 import { FollowButton } from "@/features/feed/components/follow-button";
 import { FeedAvatar } from "@/features/feed/components/feed-avatar";
 import { BlockMenuButton } from "@/features/feed/components/block-menu";
+import { MentionText } from "@/features/feed/mention-text";
 import { PostMenuButton } from "@/features/feed/components/post-menu";
 import { useFeedPrefs } from "@/features/feed/use-feed-prefs";
 import {
@@ -234,7 +235,7 @@ function CommentNode({
         {!collapsed && !editing && (
           <>
             <p className="mt-1.5 text-[13px] leading-relaxed text-slate-700 dark:text-slate-200">
-              {node.body}
+              <MentionText body={node.body} />
             </p>
             <button
               type="button"
@@ -520,7 +521,7 @@ export default function FeedThreadPage() {
 
         {post.body && (
           <p className="mt-3 text-sm italic leading-relaxed text-slate-600 dark:text-slate-300">
-            {post.body}
+            <MentionText body={post.body} />
           </p>
         )}
 

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -21,9 +21,11 @@ import {
   List,
   Globe2,
   Lock,
+  RefreshCw,
 } from "lucide-react";
 import { motion } from "motion/react";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Button as StatefulButton } from "@/components/ui/stateful-button";
@@ -67,6 +69,7 @@ import { FollowButton } from "@/features/feed/components/follow-button";
 import { FeedAvatar } from "@/features/feed/components/feed-avatar";
 import { MentionText } from "@/features/feed/mention-text";
 import { PostMenuButton } from "@/features/feed/components/post-menu";
+import { OfflineBanner } from "@/components/offline-banner";
 import { ReactionBar } from "@/features/feed/reaction-bar";
 import type { ReactionEmoji } from "@/features/feed/feed-service";
 import { FinishWhatYouStartedBanner } from "@/features/library/components/finish-what-you-started-banner";
@@ -177,6 +180,33 @@ function entrance(index: number) {
     animate: { opacity: 1, x: 0 },
     transition: { duration: 0.32, delay: Math.min(index, 10) * 0.05 },
   } as const;
+}
+
+/* ─── Refresh button ──────────────────────────────────────────────────── */
+
+/** Manual feed refresh — invalidates the ["feed", "posts"] query and
+ *  spins the icon while the refetch is in flight. Lives in the
+ *  header next to Find friends / Quiz so users don't have to wait on
+ *  the 60s background poll when they want to force a sync. */
+function FeedRefreshButton() {
+  const qc = useQueryClient();
+  const state = qc.getQueryState(["feed", "posts"]);
+  const refreshing = state?.fetchStatus === "fetching";
+  return (
+    <button
+      type="button"
+      onClick={() => qc.invalidateQueries({ queryKey: ["feed", "posts"] })}
+      disabled={refreshing}
+      title="Refresh feed"
+      aria-label="Refresh feed"
+      className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-200/80 bg-white text-slate-600 transition-colors hover:border-indigo-300 hover:text-indigo-600 disabled:opacity-60 dark:border-slate-700/70 dark:bg-slate-900/65 dark:text-slate-300 dark:hover:border-indigo-500/60 dark:hover:text-indigo-300"
+    >
+      <RefreshCw
+        size={15}
+        className={cn(refreshing && "animate-spin")}
+      />
+    </button>
+  );
 }
 
 /* ─── Post card ─────────────────────────────────────────────────────── */
@@ -1037,6 +1067,9 @@ export default function FeedPage() {
       <AppNavbar />
       <main className="px-4 pb-20 pt-28 sm:px-6 md:pt-36">
         <div className="mx-auto max-w-6xl">
+          <div className="mb-4">
+            <OfflineBanner />
+          </div>
           <div className="mb-6 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
             <div>
               <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
@@ -1066,6 +1099,7 @@ export default function FeedPage() {
                 )}
               </Link>
               <div className="flex items-center gap-2 self-start md:self-auto">
+                <FeedRefreshButton />
                 <button
                   type="button"
                   onClick={() => router.push("/feed/people")}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -200,11 +200,20 @@ function FeedRefreshButton() {
   const onClick = async () => {
     if (refreshing) return;
     setRefreshing(true);
+    // Floor the spin at ~700ms so a fast refetch (cached / instant
+    // network) doesn't half-spin and feel broken. A full rotation at
+    // tailwind's animate-spin default is ~1s, so 700ms gives roughly
+    // 3/4 of a turn — enough to read as a refresh gesture without
+    // dragging out on a slow connection.
+    const minSpin = new Promise((resolve) => setTimeout(resolve, 700));
     try {
-      await qc.refetchQueries({
-        queryKey: ["feed", "posts"],
-        type: "active",
-      });
+      await Promise.all([
+        qc.refetchQueries({
+          queryKey: ["feed", "posts"],
+          type: "active",
+        }),
+        minSpin,
+      ]);
       toast.success("Feed refreshed");
     } catch {
       toast.error("Couldn't refresh — try again.");

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -184,18 +184,38 @@ function entrance(index: number) {
 
 /* ─── Refresh button ──────────────────────────────────────────────────── */
 
-/** Manual feed refresh — invalidates the ["feed", "posts"] query and
- *  spins the icon while the refetch is in flight. Lives in the
- *  header next to Find friends / Quiz so users don't have to wait on
- *  the 60s background poll when they want to force a sync. */
+/** Manual feed refresh — refetches the ["feed", "posts"] query and
+ *  spins the icon while the request is in flight. Lives in the
+ *  header next to Find friends / Quiz so users don't have to wait
+ *  on the 60s background poll when they want to force a sync.
+ *
+ *  The success toast only fires for clicks made through this button —
+ *  background refetches (e.g. the reconnect-edge invalidation in
+ *  OfflineBanner) still spin the icon but don't toast, so the user
+ *  doesn't see a stream of "Feed refreshed" notifications they
+ *  didn't ask for. */
 function FeedRefreshButton() {
   const qc = useQueryClient();
-  const state = qc.getQueryState(["feed", "posts"]);
-  const refreshing = state?.fetchStatus === "fetching";
+  const [refreshing, setRefreshing] = useState(false);
+  const onClick = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await qc.refetchQueries({
+        queryKey: ["feed", "posts"],
+        type: "active",
+      });
+      toast.success("Feed refreshed");
+    } catch {
+      toast.error("Couldn't refresh — try again.");
+    } finally {
+      setRefreshing(false);
+    }
+  };
   return (
     <button
       type="button"
-      onClick={() => qc.invalidateQueries({ queryKey: ["feed", "posts"] })}
+      onClick={onClick}
       disabled={refreshing}
       title="Refresh feed"
       aria-label="Refresh feed"

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -57,6 +57,7 @@ import {
   useUpdatePost,
   useFollowing,
   useMyPostVotes,
+  useReactions,
   useSaved,
   useSetPostVote,
   useToggleSave,
@@ -66,6 +67,8 @@ import { FollowButton } from "@/features/feed/components/follow-button";
 import { FeedAvatar } from "@/features/feed/components/feed-avatar";
 import { MentionText } from "@/features/feed/mention-text";
 import { PostMenuButton } from "@/features/feed/components/post-menu";
+import { ReactionBar } from "@/features/feed/reaction-bar";
+import type { ReactionEmoji } from "@/features/feed/feed-service";
 import { FinishWhatYouStartedBanner } from "@/features/library/components/finish-what-you-started-banner";
 import { AiNudgeBanner } from "@/features/feed/components/ai-nudge-banner";
 import { DashboardMovedBanner } from "@/features/feed/components/dashboard-moved-banner";
@@ -185,6 +188,8 @@ function PostCard({
   onCommunity,
   view,
   index,
+  reactionCounts,
+  reactionMine,
 }: {
   post: FeedPost;
   onOpen: () => void;
@@ -194,6 +199,10 @@ function PostCard({
   onCommunity: (c: FeedCommunity) => void;
   view: FeedView;
   index: number;
+  /** Emoji counts for this post (subset of the page-level batch). */
+  reactionCounts: Partial<Record<ReactionEmoji, number>>;
+  /** Current user's pick for this post, or null. */
+  reactionMine: ReactionEmoji | null;
 }) {
   const t = tone(post.community);
   const ribbon = getRecTypeAccent(COMMUNITY_CONTENT[post.community]).stripe;
@@ -512,6 +521,12 @@ function PostCard({
               <MentionText body={post.body} />
             </p>
           )}
+          <ReactionBar
+            targetKind="post"
+            targetId={post.id}
+            counts={reactionCounts}
+            mine={reactionMine}
+          />
         </div>
       </div>
     </motion.div>
@@ -1008,6 +1023,13 @@ export default function FeedPage() {
     return list;
   }, [posts, community, scope, sort, following]);
 
+  // Single batched reactions query for every visible card — one
+  // round-trip per kind no matter how many posts render.
+  const visibleIds = useMemo(() => visible.map((p) => p.id), [visible]);
+  const { data: reactions } = useReactions({ postIds: visibleIds });
+  const reactionCounts = reactions?.counts ?? {};
+  const reactionMine = reactions?.mine ?? {};
+
   if (!ready) return <PageLoader text="Loading" />;
 
   return (
@@ -1206,6 +1228,8 @@ export default function FeedPage() {
                       onOpen={() => router.push(`/feed/${p.id}`)}
                       onEdit={() => setEditingPost(p)}
                       onCommunity={(c) => setCommunity(c)}
+                      reactionCounts={reactionCounts[p.id] ?? {}}
+                      reactionMine={reactionMine[p.id] ?? null}
                     />
                   ))
                 )}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -64,6 +64,7 @@ import {
 } from "@/features/feed/use-feed";
 import { FollowButton } from "@/features/feed/components/follow-button";
 import { FeedAvatar } from "@/features/feed/components/feed-avatar";
+import { MentionText } from "@/features/feed/mention-text";
 import { PostMenuButton } from "@/features/feed/components/post-menu";
 import { FinishWhatYouStartedBanner } from "@/features/library/components/finish-what-you-started-banner";
 import { AiNudgeBanner } from "@/features/feed/components/ai-nudge-banner";
@@ -508,7 +509,7 @@ function PostCard({
 
           {post.body && (
             <p className="mt-2 line-clamp-3 text-[13px] italic leading-relaxed text-slate-500 dark:text-slate-400">
-              {post.body}
+              <MentionText body={post.body} />
             </p>
           )}
         </div>

--- a/src/app/feed/people/page.tsx
+++ b/src/app/feed/people/page.tsx
@@ -8,7 +8,11 @@ import { AppNavbar } from "@/components/app-navbar";
 import { PageLoader } from "@/components/ui/loader";
 import { useAuth } from "@/features/auth/hooks/use-auth";
 import { useRequireAuth } from "@/features/auth/hooks/use-require-auth";
-import { useFeed, useFollowing } from "@/features/feed/use-feed";
+import {
+  useFeed,
+  useFollowSuggestions,
+  useFollowing,
+} from "@/features/feed/use-feed";
 import { FeedAvatar } from "@/features/feed/components/feed-avatar";
 import { FollowButton } from "@/features/feed/components/follow-button";
 
@@ -31,6 +35,14 @@ const PeoplePage = () => {
 
   const { data: posts, isLoading } = useFeed();
   const { data: followingIds } = useFollowing();
+  const { data: mutualSuggestions } = useFollowSuggestions();
+  const mutual = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const all = mutualSuggestions ?? [];
+    return q.length === 0
+      ? all
+      : all.filter((p) => p.name.toLowerCase().includes(q));
+  }, [mutualSuggestions, query]);
 
   const suggested = useMemo<SuggestedProfile[]>(() => {
     const followed = new Set(followingIds ?? []);
@@ -101,6 +113,45 @@ const PeoplePage = () => {
               className="w-full rounded-full border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-900/65 dark:text-slate-100 dark:focus:border-indigo-500"
             />
           </div>
+
+          {mutual.length > 0 && (
+            <>
+              <p className="mt-6 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                People you may know
+              </p>
+              <ul className="mt-3 divide-y divide-slate-200/70 overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-sm backdrop-blur-sm dark:divide-slate-700/60 dark:border-slate-700/60 dark:bg-slate-900/60">
+                {mutual.map((p) => (
+                  <li
+                    key={p.id}
+                    className="flex items-center gap-3 px-4 py-3 sm:px-5"
+                  >
+                    <FeedAvatar
+                      name={p.name}
+                      url={p.avatarUrl ?? undefined}
+                      size={36}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/feed/u/${p.id}`)}
+                      className="min-w-0 flex-1 text-left"
+                    >
+                      <p className="truncate text-sm font-black tracking-tight">
+                        {p.name}
+                      </p>
+                      <p className="text-[11px] font-semibold text-slate-500 dark:text-slate-400">
+                        {p.mutual} mutual
+                      </p>
+                    </button>
+                    <FollowButton
+                      authorId={p.id}
+                      authorName={p.name}
+                      size="sm"
+                    />
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
 
           <p className="mt-6 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
             Suggested

--- a/src/app/feed/report/page.tsx
+++ b/src/app/feed/report/page.tsx
@@ -8,8 +8,10 @@ import { toast } from "sonner";
 import { AppNavbar } from "@/components/app-navbar";
 import { Button } from "@/components/ui/button";
 import { PageLoader } from "@/components/ui/loader";
+import { useAuth } from "@/features/auth/hooks/use-auth";
 import { useRequireAuth } from "@/features/auth/hooks/use-require-auth";
 import {
+  useBlockUser,
   useReportComment,
   useReportPost,
 } from "@/features/feed/use-feed";
@@ -38,17 +40,27 @@ function ReportPageInner() {
   const router = useRouter();
   const params = useSearchParams();
   const { ready } = useRequireAuth();
+  const { user } = useAuth();
 
   const postId = params.get("postId");
   const commentId = params.get("commentId");
+  // Passed by post-menu / comment-menu so the form can offer a one-tap
+  // block alongside the report. Optional — if missing we just hide the
+  // toggle (and the toggle is also hidden when the target is yourself).
+  const authorId = params.get("authorId");
+  const author = params.get("author");
   const isPost = Boolean(postId);
   const isComment = Boolean(commentId);
 
   const [selected, setSelected] = useState<ReasonId | null>(null);
   const [details, setDetails] = useState("");
+  const [alsoBlock, setAlsoBlock] = useState(false);
 
   const reportPost = useReportPost();
   const reportComment = useReportComment();
+  const blockUser = useBlockUser();
+  const showBlockToggle =
+    !!authorId && authorId.length > 0 && authorId !== user?.id;
 
   if (!ready) {
     return <PageLoader text="Loading…" />;
@@ -86,8 +98,23 @@ function ReportPageInner() {
     const trimmed = details.trim();
     const reason = trimmed.length === 0 ? selected : `${selected}: ${trimmed}`;
     const onSuccess = () => {
-      toast.success("Thanks — we'll take a look.");
-      router.back();
+      // Block AFTER the report lands so a block failure (or a checked-but-self
+      // edge case) doesn't swallow the report's success path.
+      if (alsoBlock && authorId && authorId !== user?.id) {
+        blockUser.mutate(authorId, {
+          onSettled: () => {
+            toast.success(
+              author
+                ? `Thanks — we'll take a look. Blocked @${author}.`
+                : "Thanks — we'll take a look.",
+            );
+            router.back();
+          },
+        });
+      } else {
+        toast.success("Thanks — we'll take a look.");
+        router.back();
+      }
     };
     const onError = () =>
       toast.error("Couldn't send that report. Please try again.");
@@ -163,6 +190,25 @@ function ReportPageInner() {
             placeholder="A short note helps us prioritize."
             className="mt-2 w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:ring-rose-900/40"
           />
+
+          {showBlockToggle && (
+            <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 transition-colors hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:hover:bg-slate-800/60">
+              <input
+                type="checkbox"
+                checked={alsoBlock}
+                onChange={(e) => setAlsoBlock(e.target.checked)}
+                className="mt-0.5 h-4 w-4 accent-rose-500"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-bold text-slate-800 dark:text-slate-100">
+                  {author ? `Also block @${author}` : "Also block this person"}
+                </span>
+                <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                  You won&rsquo;t see their posts or comments anymore.
+                </span>
+              </span>
+            </label>
+          )}
 
           <Button
             type="button"

--- a/src/app/feed/report/page.tsx
+++ b/src/app/feed/report/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ArrowLeft, Flag } from "lucide-react";
+import { toast } from "sonner";
+
+import { AppNavbar } from "@/components/app-navbar";
+import { Button } from "@/components/ui/button";
+import { PageLoader } from "@/components/ui/loader";
+import { useRequireAuth } from "@/features/auth/hooks/use-require-auth";
+import {
+  useReportComment,
+  useReportPost,
+} from "@/features/feed/use-feed";
+
+/**
+ * Dedicated report flow for a post or comment. Replaces the inline
+ * `window.prompt` from the post / comment menus — gives the user a
+ * reason taxonomy and an optional free-text note, matching how other
+ * social apps handle reporting.
+ *
+ * Route: /feed/report?postId=…  or  /feed/report?commentId=…
+ */
+const REASONS = [
+  { id: "spam", label: "Spam" },
+  { id: "harassment", label: "Harassment or bullying" },
+  { id: "hate", label: "Hate speech or symbols" },
+  { id: "violence", label: "Violence or threats" },
+  { id: "sexual", label: "Sexual or explicit content" },
+  { id: "misinformation", label: "False information" },
+  { id: "other", label: "Something else" },
+] as const;
+
+type ReasonId = (typeof REASONS)[number]["id"];
+
+function ReportPageInner() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const { ready } = useRequireAuth();
+
+  const postId = params.get("postId");
+  const commentId = params.get("commentId");
+  const isPost = Boolean(postId);
+  const isComment = Boolean(commentId);
+
+  const [selected, setSelected] = useState<ReasonId | null>(null);
+  const [details, setDetails] = useState("");
+
+  const reportPost = useReportPost();
+  const reportComment = useReportComment();
+
+  if (!ready) {
+    return <PageLoader text="Loading…" />;
+  }
+
+  if (!isPost && !isComment) {
+    return (
+      <div className="min-h-screen w-full bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
+        <AppNavbar />
+        <main className="px-4 pb-20 pt-28 sm:px-6 md:pt-36">
+          <div className="mx-auto w-full max-w-[560px]">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Nothing to report — open this page from the menu on a post or
+              comment.
+            </p>
+            <button
+              type="button"
+              onClick={() => router.push("/feed")}
+              className="mt-4 inline-flex items-center gap-1.5 text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+            >
+              <ArrowLeft size={15} />
+              Back to feed
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const title = isPost ? "Report this post" : "Report this comment";
+  const busy = reportPost.isPending || reportComment.isPending;
+
+  function handleSubmit() {
+    if (!selected || busy) return;
+    const trimmed = details.trim();
+    const reason = trimmed.length === 0 ? selected : `${selected}: ${trimmed}`;
+    const onSuccess = () => {
+      toast.success("Thanks — we'll take a look.");
+      router.back();
+    };
+    const onError = () =>
+      toast.error("Couldn't send that report. Please try again.");
+    if (isPost && postId) {
+      reportPost.mutate({ postId, reason }, { onSuccess, onError });
+    } else if (isComment && commentId) {
+      reportComment.mutate({ commentId, reason }, { onSuccess, onError });
+    }
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-slate-50 text-slate-900 antialiased transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+      <AppNavbar />
+
+      <main className="px-4 pb-20 pt-28 sm:px-6 md:pt-36">
+        <div className="mx-auto w-full max-w-[560px]">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="mb-6 inline-flex items-center gap-1.5 text-sm font-bold text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            <ArrowLeft size={15} />
+            Back
+          </button>
+
+          <div className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-rose-500 dark:text-rose-400">
+            <Flag size={11} /> Report
+          </div>
+          <h1 className="mt-1 text-2xl font-black tracking-tight text-slate-900 dark:text-slate-100">
+            {title}
+          </h1>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            Tell us why so our team can take a look.
+          </p>
+
+          <fieldset className="mt-6 divide-y divide-slate-200 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:divide-slate-800 dark:border-slate-800 dark:bg-slate-900">
+            <legend className="sr-only">Report reason</legend>
+            {REASONS.map((r) => {
+              const active = selected === r.id;
+              return (
+                <label
+                  key={r.id}
+                  className="flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/60"
+                >
+                  <input
+                    type="radio"
+                    name="reason"
+                    value={r.id}
+                    checked={active}
+                    onChange={() => setSelected(r.id)}
+                    className="h-4 w-4 accent-rose-500"
+                  />
+                  <span className="text-sm font-bold text-slate-800 dark:text-slate-100">
+                    {r.label}
+                  </span>
+                </label>
+              );
+            })}
+          </fieldset>
+
+          <label
+            htmlFor="report-details"
+            className="mt-6 block text-sm font-black text-slate-800 dark:text-slate-100"
+          >
+            Add details (optional)
+          </label>
+          <textarea
+            id="report-details"
+            rows={3}
+            maxLength={500}
+            value={details}
+            onChange={(e) => setDetails(e.target.value)}
+            placeholder="A short note helps us prioritize."
+            className="mt-2 w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:ring-rose-900/40"
+          />
+
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!selected || busy}
+            className="mt-6 w-full bg-rose-500 text-white hover:bg-rose-600 disabled:cursor-not-allowed disabled:bg-rose-300 dark:bg-rose-600 dark:hover:bg-rose-500 dark:disabled:bg-rose-900"
+          >
+            {busy ? "Submitting…" : "Submit report"}
+          </Button>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default function ReportPage() {
+  // useSearchParams needs to live under a Suspense boundary in app router.
+  return (
+    <Suspense fallback={<PageLoader text="Loading…" />}>
+      <ReportPageInner />
+    </Suspense>
+  );
+}

--- a/src/app/feed/search/page.tsx
+++ b/src/app/feed/search/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { ArrowLeft, Search as SearchIcon } from "lucide-react";
+
+import { AppNavbar } from "@/components/app-navbar";
+import { PageLoader } from "@/components/ui/loader";
+import { useRequireAuth } from "@/features/auth/hooks/use-require-auth";
+import {
+  useSearchPosts,
+  useSearchProfiles,
+} from "@/features/feed/use-feed";
+import { FeedAvatar } from "@/features/feed/components/feed-avatar";
+
+/** Global search across people + picks. Two stacked sections — People
+ *  first (avatar + name + @handle), then Picks (cover thumb + title +
+ *  author). Empty / under-2-char queries render a hint card; results
+ *  debounce ~250ms after the user stops typing so we don't spam
+ *  ilike on every keystroke. Blocked users (either direction) are
+ *  filtered out in the service. */
+export default function FeedSearchPage() {
+  const router = useRouter();
+  const { ready } = useRequireAuth();
+  const [raw, setRaw] = useState("");
+  const [query, setQuery] = useState("");
+
+  // Debounce: the input is the source of truth, [query] is what we
+  // hand to react-query. Setting [query] directly on each keystroke
+  // would queue an ilike per char.
+  useEffect(() => {
+    const id = setTimeout(() => setQuery(raw.trim()), 250);
+    return () => clearTimeout(id);
+  }, [raw]);
+
+  const armed = query.length >= 2;
+  const people = useSearchProfiles(query);
+  const posts = useSearchPosts(query);
+  const peopleList = people.data ?? [];
+  const postList = posts.data ?? [];
+  const loading = armed && (people.isLoading || posts.isLoading);
+  const empty =
+    armed && !loading && peopleList.length === 0 && postList.length === 0;
+
+  if (!ready) return <PageLoader text="Loading…" />;
+
+  return (
+    <div className="min-h-screen w-full bg-slate-50 text-slate-900 antialiased transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+      <AppNavbar />
+      <main className="px-4 pb-20 pt-28 sm:px-6 md:pt-36">
+        <div className="mx-auto w-full max-w-[760px]">
+          <button
+            type="button"
+            onClick={() => router.push("/feed")}
+            className="mb-6 inline-flex items-center gap-1.5 text-sm font-bold text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            <ArrowLeft size={15} />
+            Back to feed
+          </button>
+
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
+            Search
+          </p>
+          <h1 className="mt-2 text-2xl font-black tracking-tighter sm:text-3xl md:text-4xl">
+            Find people and picks
+          </h1>
+
+          <div className="relative mt-8">
+            <SearchIcon
+              size={16}
+              className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
+            />
+            <input
+              type="text"
+              value={raw}
+              onChange={(e) => setRaw(e.target.value)}
+              placeholder="Search people and picks…"
+              autoFocus
+              className="w-full rounded-full border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-900/65 dark:text-slate-100 dark:focus:border-indigo-500"
+            />
+          </div>
+
+          {!armed ? (
+            <div className="mt-8 rounded-2xl border border-dashed border-slate-300/80 bg-white/40 px-4 py-10 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/30 dark:text-slate-400">
+              Type at least two characters to search.
+            </div>
+          ) : loading ? (
+            <div className="mt-8 px-4 py-10 text-center text-sm text-slate-400">
+              Searching…
+            </div>
+          ) : empty ? (
+            <div className="mt-8 rounded-2xl border border-dashed border-slate-300/80 bg-white/40 px-4 py-10 text-center text-sm text-slate-500 dark:border-slate-700/60 dark:bg-slate-900/30 dark:text-slate-400">
+              No matches for &ldquo;{query}&rdquo;.
+            </div>
+          ) : (
+            <div className="mt-8 space-y-8">
+              {peopleList.length > 0 && (
+                <section>
+                  <p className="text-[10px] font-black uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                    People · {peopleList.length}
+                  </p>
+                  <ul className="mt-3 divide-y divide-slate-200/70 overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-sm backdrop-blur-sm dark:divide-slate-700/60 dark:border-slate-700/60 dark:bg-slate-900/60">
+                    {peopleList.map((p) => (
+                      <li
+                        key={p.id}
+                        className="flex items-center gap-3 px-4 py-3 sm:px-5"
+                      >
+                        <FeedAvatar
+                          name={p.name}
+                          url={p.avatarUrl ?? undefined}
+                          size={36}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => router.push(`/feed/u/${p.id}`)}
+                          className="min-w-0 flex-1 text-left"
+                        >
+                          <p className="truncate text-sm font-black tracking-tight">
+                            {p.name}
+                          </p>
+                          {p.username && (
+                            <p className="truncate text-[11px] font-semibold text-slate-500 dark:text-slate-400">
+                              @{p.username}
+                            </p>
+                          )}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {postList.length > 0 && (
+                <section>
+                  <p className="text-[10px] font-black uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                    Picks · {postList.length}
+                  </p>
+                  <ul className="mt-3 divide-y divide-slate-200/70 overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-sm backdrop-blur-sm dark:divide-slate-700/60 dark:border-slate-700/60 dark:bg-slate-900/60">
+                    {postList.map((p) => (
+                      <li key={p.id}>
+                        <button
+                          type="button"
+                          onClick={() => router.push(`/feed/${p.id}`)}
+                          className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50/60 sm:px-5 dark:hover:bg-slate-800/40"
+                        >
+                          {p.posterUrl ? (
+                            <Image
+                              src={p.posterUrl}
+                              alt=""
+                              width={36}
+                              height={p.community === "music" ? 36 : 52}
+                              unoptimized
+                              className="shrink-0 rounded-md object-cover"
+                            />
+                          ) : (
+                            <div className="h-[52px] w-9 shrink-0 rounded-md bg-slate-200 dark:bg-slate-700" />
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-black tracking-tight">
+                              {p.title}
+                            </p>
+                            <p className="truncate text-[11px] font-semibold text-slate-500 dark:text-slate-400">
+                              {p.author}
+                            </p>
+                          </div>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/settings/_components/activity-notifications-card.tsx
+++ b/src/app/settings/_components/activity-notifications-card.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+  CornerDownRight,
+  MessageCircle,
+  MessageSquare,
+  ThumbsUp,
+  UserPlus,
+} from "lucide-react";
+
+import { useMutedKinds } from "@/features/notifications/use-muted-kinds";
+
+import { SectionCard, SectionHeader } from "./settings-ui";
+
+type Row = {
+  kind: string;
+  title: string;
+  description: string;
+  Icon: typeof UserPlus;
+};
+
+/** Per-kind notification toggles. One row per feed_notification_kind
+ *  enum value. Muted kinds are filtered out at useNotifications, so
+ *  the bell badge + the inbox dropdown stay in lockstep with these
+ *  switches without any additional wiring. */
+const ROWS: Row[] = [
+  {
+    kind: "follow",
+    title: "New followers",
+    description: "When someone follows you.",
+    Icon: UserPlus,
+  },
+  {
+    kind: "friend_post",
+    title: "Posts from friends",
+    description: "When someone you follow shares something new.",
+    Icon: MessageCircle,
+  },
+  {
+    kind: "comment_on_post",
+    title: "Comments on your posts",
+    description: "When someone comments on a post you wrote.",
+    Icon: MessageSquare,
+  },
+  {
+    kind: "reply_to_comment",
+    title: "Replies to your comments",
+    description: "When someone replies to a comment you left.",
+    Icon: CornerDownRight,
+  },
+  {
+    kind: "post_upvote",
+    title: "Upvotes on your posts",
+    description: "When someone upvotes a post you wrote.",
+    Icon: ThumbsUp,
+  },
+  {
+    kind: "comment_upvote",
+    title: "Upvotes on your comments",
+    description: "When someone upvotes a comment you left.",
+    Icon: ThumbsUp,
+  },
+];
+
+export function ActivityNotificationsCard() {
+  const { muted, setMuted } = useMutedKinds();
+  return (
+    <SectionCard>
+      <SectionHeader
+        title="Activity"
+        description="What other people do — pick which of these show up in your inbox and the bell badge."
+      />
+      <ul className="divide-y divide-slate-200 overflow-hidden rounded-2xl border border-slate-200 bg-white dark:divide-slate-800 dark:border-slate-800 dark:bg-slate-900">
+        {ROWS.map(({ kind, title, description, Icon }) => {
+          const on = !muted.has(kind);
+          const id = `notif-${kind}`;
+          return (
+            <li
+              key={kind}
+              className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/60"
+            >
+              <Icon
+                size={18}
+                className="shrink-0 text-slate-500 dark:text-slate-400"
+                aria-hidden
+              />
+              <label
+                htmlFor={id}
+                className="flex-1 cursor-pointer select-none"
+              >
+                <span className="block text-sm font-bold text-slate-800 dark:text-slate-100">
+                  {title}
+                </span>
+                <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                  {description}
+                </span>
+              </label>
+              <input
+                id={id}
+                type="checkbox"
+                role="switch"
+                checked={on}
+                onChange={(e) => setMuted(kind, !e.target.checked)}
+                aria-label={title}
+                className="h-5 w-5 accent-indigo-500"
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </SectionCard>
+  );
+}

--- a/src/app/settings/_components/blocked-people-card.tsx
+++ b/src/app/settings/_components/blocked-people-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import { ShieldOff, UserX } from "lucide-react";
+import { Search, ShieldOff } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -12,20 +12,33 @@ import {
 
 import { SectionCard, SectionHeader } from "./settings-ui";
 
+/** Once the list passes this threshold the card shows a live search
+ *  field — for a handful of blocked profiles the search box adds
+ *  more chrome than it saves. */
+const SEARCH_THRESHOLD = 6;
+
 /**
  * Settings → Feed "Blocked people" block. Lists every blocked profile
- * (from feed_blocks) with an unblock button. Empty-state when the list
- * is clean.
+ * (from feed_blocks) with their avatar + an unblock button; a live
+ * search field is lazily added once the list is long enough to be
+ * worth filtering.
  */
 export const BlockedPeopleCard = () => {
   const t = useTranslations("Settings.feed.blocked");
   const { data: blocked } = useBlockedProfiles();
   const unblockUser = useUnblockUser();
+  const [query, setQuery] = useState("");
 
   const handles = useMemo(
     () => [...(blocked ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
     [blocked],
   );
+
+  const q = query.trim().toLowerCase();
+  const visible = q
+    ? handles.filter((p) => p.name.toLowerCase().includes(q))
+    : handles;
+  const showSearch = handles.length >= SEARCH_THRESHOLD;
 
   return (
     <SectionCard>
@@ -42,39 +55,81 @@ export const BlockedPeopleCard = () => {
           </p>
         </div>
       ) : (
-        <ul className="space-y-2">
-          {handles.map((profile) => (
-            <li
-              key={profile.id}
-              className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-2.5 dark:border-slate-700 dark:bg-slate-900/60"
-            >
-              <span className="flex items-center gap-2 text-sm">
-                <UserX
-                  size={14}
-                  className="text-rose-500 dark:text-rose-400"
-                  aria-hidden
-                />
-                <span className="font-semibold text-slate-800 dark:text-slate-100">
-                  @{profile.name}
-                </span>
+        <>
+          <div className="mb-3 flex items-center justify-between gap-3 text-xs text-slate-500 dark:text-slate-400">
+            <span className="font-bold uppercase tracking-wide">
+              {handles.length} blocked
+            </span>
+            {showSearch && q && (
+              <span>
+                {visible.length}{" "}
+                {visible.length === 1 ? "match" : "matches"}
               </span>
-              <button
-                type="button"
-                onClick={() => {
-                  unblockUser.mutate(profile.id, {
-                    onSuccess: () =>
-                      toast.message(
-                        t("unblockedToast", { handle: profile.name }),
-                      ),
-                  });
-                }}
-                className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-bold text-emerald-700 transition-colors hover:bg-emerald-500/15 dark:bg-emerald-400/15 dark:text-emerald-300"
-              >
-                {t("unblock")}
-              </button>
-            </li>
-          ))}
-        </ul>
+            )}
+          </div>
+          {showSearch && (
+            <div className="relative mb-3">
+              <Search
+                size={14}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+                aria-hidden
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search by name"
+                className="w-full rounded-xl border border-slate-200 bg-white py-2 pl-9 pr-3 text-sm text-slate-800 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100"
+              />
+            </div>
+          )}
+          {visible.length === 0 ? (
+            <p className="py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+              No matches.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {visible.map((profile) => (
+                <li
+                  key={profile.id}
+                  className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-2 dark:border-slate-700 dark:bg-slate-900/60"
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    {profile.avatarUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={profile.avatarUrl}
+                        alt=""
+                        className="h-9 w-9 shrink-0 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-rose-500/10 text-sm font-bold text-rose-600 dark:bg-rose-400/15 dark:text-rose-300">
+                        {(profile.name[0] ?? "?").toUpperCase()}
+                      </div>
+                    )}
+                    <span className="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+                      @{profile.name}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      unblockUser.mutate(profile.id, {
+                        onSuccess: () =>
+                          toast.message(
+                            t("unblockedToast", { handle: profile.name }),
+                          ),
+                      });
+                    }}
+                    className="shrink-0 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-bold text-emerald-700 transition-colors hover:bg-emerald-500/15 dark:bg-emerald-400/15 dark:text-emerald-300"
+                  >
+                    {t("unblock")}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </SectionCard>
   );

--- a/src/app/settings/_components/my-reports-card.tsx
+++ b/src/app/settings/_components/my-reports-card.tsx
@@ -4,8 +4,44 @@ import { useTranslations } from "next-intl";
 import { Flag } from "lucide-react";
 
 import { useMyReports } from "@/features/feed/use-feed";
+import type { ReportStatus } from "@/features/feed/feed-service";
 
 import { SectionCard, SectionHeader } from "./settings-ui";
+
+/** Pill describing where a report sits in the moderation queue —
+ *  shared with the admin Reports surface so the same vocabulary is
+ *  used on both sides. */
+function ReportStatusBadge({
+  status,
+  reviewedLabel,
+  dismissedLabel,
+  reviewLabel,
+}: {
+  status: ReportStatus;
+  reviewedLabel: string;
+  dismissedLabel: string;
+  reviewLabel: string;
+}) {
+  if (status === "reviewed") {
+    return (
+      <span className="shrink-0 rounded-full bg-emerald-500/10 px-2.5 py-1 text-[11px] font-bold text-emerald-700 dark:bg-emerald-400/15 dark:text-emerald-300">
+        {reviewedLabel}
+      </span>
+    );
+  }
+  if (status === "dismissed") {
+    return (
+      <span className="shrink-0 rounded-full bg-slate-500/10 px-2.5 py-1 text-[11px] font-bold text-slate-600 dark:bg-slate-400/15 dark:text-slate-300">
+        {dismissedLabel}
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 rounded-full bg-amber-500/10 px-2.5 py-1 text-[11px] font-bold text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">
+      {reviewLabel}
+    </span>
+  );
+}
 
 /**
  * Settings → Feed "Reports you've filed" block. Lists the reports the
@@ -56,9 +92,12 @@ export const MyReportsCard = () => {
                   </p>
                 )}
               </div>
-              <span className="shrink-0 rounded-full bg-amber-500/10 px-2.5 py-1 text-[11px] font-bold text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">
-                {t("statusReview")}
-              </span>
+              <ReportStatusBadge
+                status={report.status}
+                reviewLabel={t("statusReview")}
+                reviewedLabel={t("statusReviewed")}
+                dismissedLabel={t("statusDismissed")}
+              />
             </li>
           ))}
         </ul>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -28,6 +28,7 @@ import {
   UserPlus,
   Trophy,
   UserCircle,
+  Megaphone,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { motion, AnimatePresence } from "motion/react";
@@ -1646,6 +1647,23 @@ const SettingsPage = () => {
                             </span>
                             <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
                               {t("help.milestones.subtitle")}
+                            </span>
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => router.push("/changelog")}
+                          className="flex w-full items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:border-emerald-300 hover:bg-emerald-50/40 dark:border-slate-700 dark:bg-slate-900/60 dark:hover:border-emerald-500/60 dark:hover:bg-emerald-500/10"
+                        >
+                          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-300">
+                            <Megaphone size={18} />
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-sm font-semibold text-slate-800 dark:text-slate-100">
+                              What&apos;s new
+                            </span>
+                            <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                              Recent feature drops, newest first.
                             </span>
                           </span>
                         </button>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
@@ -1586,7 +1587,7 @@ const SettingsPage = () => {
                         description={t("help.description")}
                       />
                       <div className="space-y-3">
-                        <a
+                        <Link
                           href="/#faq"
                           className="flex w-full items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:bg-slate-900/60 dark:hover:border-indigo-500/60 dark:hover:bg-indigo-500/10"
                         >
@@ -1601,7 +1602,7 @@ const SettingsPage = () => {
                               {t("help.faq.subtitle")}
                             </span>
                           </span>
-                        </a>
+                        </Link>
                         <button
                           type="button"
                           onClick={() => router.push("/quiz")}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -29,6 +29,7 @@ import {
   Trophy,
   UserCircle,
   Megaphone,
+  ShieldAlert,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { motion, AnimatePresence } from "motion/react";
@@ -78,6 +79,7 @@ import {
   useFeedPrefs,
   type FeedView,
 } from "@/features/feed/use-feed-prefs";
+import { useIsAdmin } from "@/features/feed/use-feed";
 import type {
   CommentSort,
   FeedCommunity,
@@ -185,6 +187,7 @@ const SettingsPage = () => {
   const { user, refreshUser } = useAuth();
   const { ready } = useRequireAuth();
   const [feedVisibility, setFeedVisibility] = useFeedVisibility();
+  const { data: isAdmin = false } = useIsAdmin();
   const [feedPrefs, setFeedPrefs] = useFeedPrefs();
 
   const settingsTabs = SETTINGS_SECTIONS;
@@ -1650,6 +1653,25 @@ const SettingsPage = () => {
                             </span>
                           </span>
                         </button>
+                        {isAdmin && (
+                          <button
+                            type="button"
+                            onClick={() => router.push("/admin/reports")}
+                            className="flex w-full items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:border-rose-300 hover:bg-rose-50/40 dark:border-slate-700 dark:bg-slate-900/60 dark:hover:border-rose-500/60 dark:hover:bg-rose-500/10"
+                          >
+                            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-rose-600 dark:bg-rose-500/15 dark:text-rose-300">
+                              <ShieldAlert size={18} />
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="block text-sm font-semibold text-slate-800 dark:text-slate-100">
+                                Reports moderation
+                              </span>
+                              <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                                Triage user-filed reports on posts and comments.
+                              </span>
+                            </span>
+                          </button>
+                        )}
                         <button
                           type="button"
                           onClick={() => router.push("/changelog")}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
@@ -1559,7 +1560,7 @@ const SettingsPage = () => {
                         description={t("help.description")}
                       />
                       <div className="space-y-3">
-                        <a
+                        <Link
                           href="/#faq"
                           className="flex w-full items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:bg-slate-900/60 dark:hover:border-indigo-500/60 dark:hover:bg-indigo-500/10"
                         >
@@ -1574,7 +1575,7 @@ const SettingsPage = () => {
                               {t("help.faq.subtitle")}
                             </span>
                           </span>
-                        </a>
+                        </Link>
                         <button
                           type="button"
                           onClick={() => router.push("/quiz")}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
+  Bell,
   CircleOff,
   Shield,
   SlidersHorizontal,
@@ -54,6 +55,7 @@ import {
   SettingsInput,
 } from "./_components/settings-ui";
 import { RecommendationFiltersCard } from "./_components/recommendation-filters-card";
+import { ActivityNotificationsCard } from "./_components/activity-notifications-card";
 import { BlockedPeopleCard } from "./_components/blocked-people-card";
 import { MyReportsCard } from "./_components/my-reports-card";
 import { usePasswordRules } from "./_hooks/use-password-rules";
@@ -104,6 +106,7 @@ type SettingsSection =
   | "security"
   | "content"
   | "feed"
+  | "notifications"
   | "integrations"
   | "help";
 
@@ -112,6 +115,7 @@ const SETTINGS_SECTIONS: SettingsSection[] = [
   "security",
   "content",
   "feed",
+  "notifications",
   "integrations",
   "help",
 ];
@@ -363,6 +367,11 @@ const SettingsPage = () => {
     },
     { id: "feed", label: t("tabs.feed"), icon: <Newspaper size={15} /> },
     {
+      id: "notifications",
+      label: t("tabs.notifications"),
+      icon: <Bell size={15} />,
+    },
+    {
       id: "integrations",
       label: t("tabs.integrations"),
       icon: <Link2 size={15} />,
@@ -498,6 +507,7 @@ const SettingsPage = () => {
                     (tab) =>
                       tab.id === "content" ||
                       tab.id === "feed" ||
+                      tab.id === "notifications" ||
                       tab.id === "integrations" ||
                       tab.id === "help",
                   )
@@ -1475,6 +1485,19 @@ const SettingsPage = () => {
 
                     <BlockedPeopleCard />
                     <MyReportsCard />
+                  </motion.div>
+                )}
+
+                {activeSection === "notifications" && (
+                  <motion.div
+                    key="notifications"
+                    initial={{ opacity: 0, x: sectionSlideDir * 30 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: sectionSlideDir * -30 }}
+                    transition={{ duration: 0.2 }}
+                    className="space-y-4"
+                  >
+                    <ActivityNotificationsCard />
                   </motion.div>
                 )}
 

--- a/src/components/app-navbar.tsx
+++ b/src/components/app-navbar.tsx
@@ -6,6 +6,7 @@ import { LogOut } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useAuth } from "@/features/auth/hooks/use-auth";
+import { NotificationsBell } from "@/features/feed/components/notifications-bell";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
 import { HoverBorderGradient } from "@/components/ui/hover-border-gradient";
@@ -132,7 +133,12 @@ export function AppNavbar() {
               {primaryLabel}
             </HoverBorderGradient>
           ) : (
-            user && <UserAvatarMenu />
+            user && (
+              <>
+                <NotificationsBell />
+                <UserAvatarMenu />
+              </>
+            )
           )}
         </div>
       </NavBody>
@@ -152,7 +158,10 @@ export function AppNavbar() {
             // Authed mobile users get the same avatar dropdown as desktop —
             // mirrors the right-side anchor users expect and pulls theme +
             // sign out into a tidy menu instead of leaving the bar bare.
-            <UserAvatarMenu />
+            <div className="flex items-center gap-1">
+              <NotificationsBell />
+              <UserAvatarMenu />
+            </div>
           )}
         </MobileNavHeader>
 

--- a/src/components/app-navbar.tsx
+++ b/src/components/app-navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { LogOut } from "lucide-react";
+import { LogOut, Search as SearchIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useAuth } from "@/features/auth/hooks/use-auth";
@@ -135,6 +135,14 @@ export function AppNavbar() {
           ) : (
             user && (
               <>
+                <button
+                  type="button"
+                  onClick={() => router.push("/feed/search")}
+                  aria-label="Search"
+                  className="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+                >
+                  <SearchIcon size={18} />
+                </button>
                 <NotificationsBell />
                 <UserAvatarMenu />
               </>

--- a/src/components/offline-banner.tsx
+++ b/src/components/offline-banner.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AnimatePresence, motion } from "motion/react";
+import { WifiOff } from "lucide-react";
+
+/** Inline "You're offline" strip — scoped to the feed pages where
+ *  the live/stale distinction matters most. Pairs with the
+ *  offline→online edge-detection below so the feed auto-refreshes
+ *  when the network comes back.
+ *
+ *  `navigator.onLine` reports a *transport* state, not real
+ *  reachability — a browser on a captive-portal wifi will read as
+ *  online here even though requests fail. That's intentional:
+ *  catching captive portals would need a probe-per-period (cost) and
+ *  false negatives are worse than missed positives for this UX. */
+export function OfflineBanner() {
+  const qc = useQueryClient();
+  const [online, setOnline] = useState(true);
+  // SSR doesn't have navigator, so the first client render starts
+  // online and corrects on mount — otherwise the banner would
+  // hydrate-flash on every page load.
+  const wasOnlineRef = useRef(true);
+
+  useEffect(() => {
+    const initial = typeof navigator === "undefined" ? true : navigator.onLine;
+    setOnline(initial);
+    wasOnlineRef.current = initial;
+    const onOnline = () => {
+      setOnline(true);
+      // offline→online edge: invalidate the feed family so the
+      // user's screen reloads with fresh data instead of stranding
+      // on the cached error state from the dropped fetch.
+      if (!wasOnlineRef.current) {
+        qc.invalidateQueries({ queryKey: ["feed"] });
+      }
+      wasOnlineRef.current = true;
+    };
+    const onOffline = () => {
+      setOnline(false);
+      wasOnlineRef.current = false;
+    };
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
+  }, [qc]);
+
+  return (
+    <AnimatePresence initial={false}>
+      {!online && (
+        <motion.div
+          key="offline"
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: "auto", opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+          role="status"
+          aria-live="polite"
+          className="overflow-hidden"
+        >
+          <div className="flex items-center justify-center gap-2 rounded-2xl border border-amber-300 bg-amber-50 px-3 py-2 text-[12px] font-bold text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
+            <WifiOff size={12} aria-hidden />
+            <span>You&rsquo;re offline — the feed is paused</span>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/feed/components/notifications-bell.tsx
+++ b/src/features/feed/components/notifications-bell.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import {
+  Bell,
+  MessageCircle,
+  CornerDownRight,
+  Heart,
+  MessageSquare,
+  ThumbsUp,
+  Trash2,
+  UserPlus,
+} from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  useClearAllNotifications,
+  useDeleteNotification,
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+  useUnreadNotificationsCount,
+} from "@/features/feed/use-feed";
+import type { FeedNotification } from "@/features/feed/feed-service";
+import { cn } from "@/lib/utils";
+
+/** Per-kind icon + accent. Keep these in sync with the mobile inbox
+ *  cards (apps/mobile/lib/features/notifications/notifications_screen.dart)
+ *  so the same kinds read the same way on both clients. */
+function kindStyle(kind: string): { Icon: typeof Bell; color: string } {
+  switch (kind) {
+    case "follow":
+      return { Icon: UserPlus, color: "text-indigo-500" };
+    case "comment_on_post":
+      return { Icon: MessageSquare, color: "text-violet-500" };
+    case "reply_to_comment":
+      return { Icon: CornerDownRight, color: "text-violet-500" };
+    case "friend_post":
+      return { Icon: MessageCircle, color: "text-emerald-500" };
+    case "post_upvote":
+    case "comment_upvote":
+      return { Icon: ThumbsUp, color: "text-amber-500" };
+    default:
+      return { Icon: Heart, color: "text-slate-500" };
+  }
+}
+
+function titleFor(n: FeedNotification): string {
+  switch (n.kind) {
+    case "follow":
+      return `${n.actorName} started following you`;
+    case "comment_on_post":
+      return `${n.actorName} commented on your post`;
+    case "reply_to_comment":
+      return `${n.actorName} replied to your comment`;
+    case "friend_post":
+      return `${n.actorName} shared a new post`;
+    case "post_upvote":
+      return `${n.actorName} upvoted your post`;
+    case "comment_upvote":
+      return `${n.actorName} upvoted your comment`;
+    default:
+      return `${n.actorName} interacted with you`;
+  }
+}
+
+function subtitleFor(n: FeedNotification): string | null {
+  const body = (n.commentBody ?? "").trim();
+  const title = (n.postTitle ?? "").trim();
+  if (body) return `“${body}”`;
+  if (title) return title;
+  return null;
+}
+
+function routeFor(n: FeedNotification): string | null {
+  if (n.postId) return `/feed/${n.postId}`;
+  if (n.kind === "follow" && n.actorId) return `/feed/u/${n.actorId}`;
+  return null;
+}
+
+function ago(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  if (d < 365) return `${Math.floor(d / 7)}w ago`;
+  return `${Math.floor(d / 365)}y ago`;
+}
+
+/** Navbar bell — opens an inbox dropdown of `feed_notifications`. Reads
+ *  the live React Query cache (which the rest of the feed already
+ *  populates) so opening the panel is instant. Marks everything read
+ *  the first time the panel opens with anything unread, so the badge
+ *  clears as soon as the user acknowledges. */
+export function NotificationsBell() {
+  const router = useRouter();
+  const { data: items = [] } = useNotifications();
+  const unread = useUnreadNotificationsCount();
+  const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
+  const deleteOne = useDeleteNotification();
+  const clearAll = useClearAllNotifications();
+
+  return (
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (open && unread > 0) markAllRead.mutate();
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={
+            unread > 0 ? `Notifications, ${unread} unread` : "Notifications"
+          }
+          className="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+        >
+          <Bell size={18} />
+          {unread > 0 && (
+            <span className="absolute right-1 top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold leading-none text-white ring-2 ring-white dark:ring-slate-900">
+              {unread > 99 ? "99+" : unread}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className="w-[360px] p-0"
+      >
+        <div className="flex items-center justify-between border-b border-slate-200 px-4 py-2.5 dark:border-slate-800">
+          <p className="text-sm font-bold text-slate-700 dark:text-slate-200">
+            Notifications
+          </p>
+          {items.length > 0 && (
+            <button
+              type="button"
+              onClick={() => clearAll.mutate()}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            >
+              <Trash2 size={12} />
+              Clear
+            </button>
+          )}
+        </div>
+        <div className="max-h-[420px] overflow-y-auto">
+          {items.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
+              <Bell
+                size={28}
+                className="text-slate-300 dark:text-slate-600"
+                aria-hidden
+              />
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                You&rsquo;re all caught up.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-slate-200 dark:divide-slate-800">
+              {items.map((n) => {
+                const { Icon, color } = kindStyle(n.kind);
+                const subtitle = subtitleFor(n);
+                const route = routeFor(n);
+                const isClickable = route !== null;
+                return (
+                  <li
+                    key={n.id}
+                    className={cn(
+                      "group flex items-start gap-3 px-3 py-3 transition-colors",
+                      isClickable &&
+                        "cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/40",
+                      n.readAt === null && "bg-indigo-500/[0.04]",
+                    )}
+                    onClick={() => {
+                      if (!isClickable) return;
+                      if (n.readAt === null) markRead.mutate(n.id);
+                      router.push(route!);
+                    }}
+                  >
+                    <div className="relative h-9 w-9 shrink-0">
+                      {n.actorAvatarUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={n.actorAvatarUrl}
+                          alt=""
+                          className="h-9 w-9 rounded-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-500/10 text-sm font-bold text-indigo-600 dark:bg-indigo-400/15 dark:text-indigo-300">
+                          {(n.actorName[0] ?? "?").toUpperCase()}
+                        </div>
+                      )}
+                      <span
+                        className={cn(
+                          "absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full ring-2 ring-white dark:ring-slate-900",
+                          "bg-white dark:bg-slate-900",
+                        )}
+                      >
+                        <Icon
+                          size={10}
+                          className={color}
+                          aria-hidden
+                        />
+                      </span>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+                        {titleFor(n)}
+                      </p>
+                      {subtitle && (
+                        <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">
+                          {subtitle}
+                        </p>
+                      )}
+                      <p className="mt-0.5 text-[11px] font-medium text-slate-400 dark:text-slate-500">
+                        {ago(n.createdAt)}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      aria-label="Dismiss notification"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteOne.mutate(n.id);
+                      }}
+                      className="hidden h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-200 hover:text-slate-700 group-hover:flex dark:hover:bg-slate-700 dark:hover:text-slate-200"
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Optional helper for layouts that want to refresh the bell on a
+ *  client-side event (e.g. after a comment post). Returns a stable
+ *  refresh callback. */
+export function useNotificationsRefresher() {
+  const { refetch } = useNotifications();
+  useEffect(() => {
+    // No-op effect to make this a hook; refetch is exposed below.
+  }, []);
+  return refetch;
+}

--- a/src/features/feed/components/post-menu.tsx
+++ b/src/features/feed/components/post-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   MoreHorizontal,
   Pencil,
@@ -20,7 +21,6 @@ import { useAuth } from "@/features/auth/hooks/use-auth";
 import {
   useBlockUser,
   useDeletePost,
-  useReportPost,
 } from "@/features/feed/use-feed";
 import { cn } from "@/lib/utils";
 
@@ -75,10 +75,10 @@ export function PostMenuButton({
   size = 16,
   className,
 }: PostMenuButtonProps) {
+  const router = useRouter();
   const { user } = useAuth();
   const blockUser = useBlockUser();
   const deletePost = useDeletePost();
-  const reportPost = useReportPost();
 
   if (!authorId) return null;
   const isOwn = authorId === user?.id;
@@ -151,23 +151,11 @@ export function PostMenuButton({
         ) : (
           <>
             <DropdownMenuItem
-              onSelect={() => {
-                const reason = window.prompt(
-                  "Report this post? Optionally tell us what's wrong:",
-                );
-                if (reason === null) return;
-                reportPost.mutate(
-                  { postId, reason: reason || undefined },
-                  {
-                    onSuccess: () =>
-                      toast.success(
-                        "Report submitted — thanks for flagging it.",
-                      ),
-                    onError: () =>
-                      toast.error("Couldn't submit the report — try again."),
-                  },
-                );
-              }}
+              onSelect={() =>
+                router.push(
+                  `/feed/report?postId=${encodeURIComponent(postId)}`,
+                )
+              }
               className="gap-2"
             >
               <Flag size={14} />

--- a/src/features/feed/components/post-menu.tsx
+++ b/src/features/feed/components/post-menu.tsx
@@ -151,11 +151,14 @@ export function PostMenuButton({
         ) : (
           <>
             <DropdownMenuItem
-              onSelect={() =>
-                router.push(
-                  `/feed/report?postId=${encodeURIComponent(postId)}`,
-                )
-              }
+              onSelect={() => {
+                const qs = new URLSearchParams({
+                  postId,
+                  ...(authorId ? { authorId } : {}),
+                  ...(author ? { author } : {}),
+                }).toString();
+                router.push(`/feed/report?${qs}`);
+              }}
               className="gap-2"
             >
               <Flag size={14} />

--- a/src/features/feed/components/post-menu.tsx
+++ b/src/features/feed/components/post-menu.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   MoreHorizontal,
   Pencil,
+  Send,
   Share2,
   Flag,
   Trash2,
   UserX,
 } from "lucide-react";
 import { toast } from "sonner";
+
+import { SendPickDialog } from "@/features/feed/send-pick-dialog";
 
 import {
   DropdownMenu,
@@ -79,6 +83,7 @@ export function PostMenuButton({
   const { user } = useAuth();
   const blockUser = useBlockUser();
   const deletePost = useDeletePost();
+  const [sendOpen, setSendOpen] = useState(false);
 
   if (!authorId) return null;
   const isOwn = authorId === user?.id;
@@ -89,6 +94,7 @@ export function PostMenuButton({
       : "text-slate-400 hover:text-slate-700 dark:text-slate-500 dark:hover:text-slate-200";
 
   return (
+    <>
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
@@ -116,6 +122,23 @@ export function PostMenuButton({
           <DropdownMenuItem onSelect={() => onEdit()} className="gap-2">
             <Pencil size={14} />
             Edit post
+          </DropdownMenuItem>
+        )}
+
+        {user && (
+          <DropdownMenuItem
+            onSelect={(e) => {
+              // The Radix dropdown closes-then-fires onSelect; defer so the
+              // dialog opens after the menu has unmounted (otherwise the
+              // backdrop pointer-events race makes the dialog
+              // un-clickable for a frame).
+              e.preventDefault();
+              setSendOpen(true);
+            }}
+            className="gap-2"
+          >
+            <Send size={14} />
+            Send to a friend
           </DropdownMenuItem>
         )}
 
@@ -186,5 +209,12 @@ export function PostMenuButton({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+    <SendPickDialog
+      open={sendOpen}
+      onClose={() => setSendOpen(false)}
+      postId={postId}
+      postTitle={postTitle}
+    />
+    </>
   );
 }

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -655,6 +655,111 @@ export async function setReaction(args: {
   );
 }
 
+export interface SearchProfileResult {
+  id: string;
+  name: string;
+  username: string | null;
+  avatarUrl: string | null;
+}
+
+export interface SearchPostResult {
+  id: string;
+  title: string;
+  body: string | null;
+  posterUrl: string | null;
+  community: FeedCommunity;
+  authorId: string;
+  author: string;
+}
+
+/** Escapes `%` and `_` so a literal "50%" search doesn't act as a
+ *  wildcard. Used by both search functions below. */
+function escapeIlike(s: string): string {
+  return s.replace(/[%_]/g, (m) => `\\${m}`);
+}
+
+/** Debounced caller is in the search page; the service itself returns
+ *  whatever ilike finds. Blocked users (either direction) are filtered
+ *  out so search never surfaces someone you've cut contact with. */
+export async function searchProfiles(
+  query: string,
+): Promise<SearchProfileResult[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+  const like = `%${escapeIlike(q)}%`;
+  const [{ data: rows }, blocked, blockedBy] = await Promise.all([
+    supabase
+      .from("profiles_public")
+      .select("id, name, username, avatar_url")
+      .or(`name.ilike.${like},username.ilike.${like}`)
+      .limit(30),
+    fetchBlocked(),
+    fetchBlockedBy(),
+  ]);
+  const hidden = new Set<string>([...blocked, ...blockedBy]);
+  const out: SearchProfileResult[] = [];
+  for (const r of (rows ?? []) as Array<{
+    id: string | null;
+    name: string | null;
+    username: string | null;
+    avatar_url: string | null;
+  }>) {
+    if (!r.id || hidden.has(r.id)) continue;
+    out.push({
+      id: r.id,
+      name: r.name ?? "Someone",
+      username: r.username,
+      avatarUrl: r.avatar_url,
+    });
+  }
+  return out;
+}
+
+export async function searchPosts(
+  query: string,
+): Promise<SearchPostResult[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+  const like = `%${escapeIlike(q)}%`;
+  type Row = {
+    id: string;
+    title: string | null;
+    body: string | null;
+    poster_url: string | null;
+    community: FeedCommunity;
+    author: { id: string; name: string | null } | null;
+  };
+  const [{ data: rows }, blocked, blockedBy] = await Promise.all([
+    supabase
+      .from("feed_posts")
+      .select(
+        "id, title, body, poster_url, community, " +
+          "author:profiles_public!feed_posts_user_id_fkey ( id, name )",
+      )
+      .or(`title.ilike.${like},body.ilike.${like}`)
+      .order("created_at", { ascending: false })
+      .limit(30),
+    fetchBlocked(),
+    fetchBlockedBy(),
+  ]);
+  const hidden = new Set<string>([...blocked, ...blockedBy]);
+  const out: SearchPostResult[] = [];
+  for (const r of (rows ?? []) as unknown as Row[]) {
+    const authorId = r.author?.id ?? "";
+    if (!authorId || hidden.has(authorId)) continue;
+    out.push({
+      id: r.id,
+      title: r.title ?? "",
+      body: r.body,
+      posterUrl: r.poster_url,
+      community: r.community,
+      authorId,
+      author: r.author?.name ?? "Someone",
+    });
+  }
+  return out;
+}
+
 export interface FollowSuggestion {
   id: string;
   name: string;

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -655,6 +655,74 @@ export async function setReaction(args: {
   );
 }
 
+export interface FollowSuggestion {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  /** How many of the current user's follows also follow this person. */
+  mutual: number;
+}
+
+/** Friends-of-friends ranked by mutual-overlap count. Returns empty
+ *  when the current user follows no-one (caller pairs this with
+ *  [fetchSuggestedPeople] for the cold-start surface). Hidden:
+ *  yourself, anyone you already follow, anyone either side has
+ *  blocked. */
+export async function fetchFollowSuggestions(
+  limit = 30,
+): Promise<FollowSuggestion[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+  const mine = await fetchFollowing();
+  if (mine.length === 0) return [];
+  type Row = {
+    follower_id: string;
+    followee: { id: string; name: string; avatar_url: string | null } | null;
+  };
+  const [{ data: rows }, blocked, blockedBy] = await Promise.all([
+    supabase
+      .from("feed_follows")
+      .select(
+        "follower_id, " +
+          "followee:profiles_public!feed_follows_followee_id_fkey ( id, name, avatar_url )",
+      )
+      .in("follower_id", mine),
+    fetchBlocked(),
+    fetchBlockedBy(),
+  ]);
+  const hidden = new Set<string>([
+    user.id,
+    ...mine,
+    ...blocked,
+    ...blockedBy,
+  ]);
+  const scored = new Map<
+    string,
+    { name: string; avatarUrl: string | null; mutual: number }
+  >();
+  for (const r of (rows ?? []) as unknown as Row[]) {
+    const p = r.followee;
+    if (!p?.id || hidden.has(p.id)) continue;
+    const prev = scored.get(p.id);
+    scored.set(p.id, {
+      name: p.name ?? "Someone",
+      avatarUrl: p.avatar_url,
+      mutual: (prev?.mutual ?? 0) + 1,
+    });
+  }
+  const entries = [...scored.entries()].sort(
+    (a, b) => b[1].mutual - a[1].mutual,
+  );
+  return entries.slice(0, limit).map(([id, v]) => ({
+    id,
+    name: v.name,
+    avatarUrl: v.avatarUrl,
+    mutual: v.mutual,
+  }));
+}
+
 /** Looks up a profile id from a `@handle` (case-insensitive).
  *  Backs the @mention tap-handler in [MentionText]; returns `null`
  *  when the handle doesn't exist (don't throw — the UI shows a

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -314,6 +314,8 @@ export function reportComment(
 }
 
 /** A report the current user filed — for the Settings reports list. */
+export type ReportStatus = "open" | "reviewed" | "dismissed";
+
 export interface MyReport {
   id: string;
   reason: string | null;
@@ -321,6 +323,7 @@ export interface MyReport {
   target: "post" | "comment";
   /** Post title / comment snippet, when the content still exists. */
   targetLabel: string | null;
+  status: ReportStatus;
 }
 
 /** Reports the current user has filed, newest first. */
@@ -332,7 +335,7 @@ export async function fetchMyReports(): Promise<MyReport[]> {
   const { data, error } = await supabase
     .from("feed_reports")
     .select(
-      `id, reason, created_at, post_id, comment_id,
+      `id, reason, created_at, post_id, comment_id, status,
        post:feed_posts!feed_reports_post_id_fkey ( title ),
        comment:feed_comments!feed_reports_comment_id_fkey ( body )`,
     )
@@ -345,6 +348,7 @@ export async function fetchMyReports(): Promise<MyReport[]> {
     created_at: string;
     post_id: string | null;
     comment_id: string | null;
+    status: string | null;
     post: { title: string } | { title: string }[] | null;
     comment: { body: string } | { body: string }[] | null;
   }[];
@@ -359,8 +363,115 @@ export async function fetchMyReports(): Promise<MyReport[]> {
       createdAt: r.created_at,
       target: r.post_id ? ("post" as const) : ("comment" as const),
       targetLabel: post?.title ?? comment?.body ?? null,
+      status: ((r.status ?? "open") as ReportStatus),
     };
   });
+}
+
+/** Admin-only triage list — every report in the system, newest first.
+ *  Reads via the `feed_reports_select_admin` RLS policy
+ *  (profiles.is_admin = TRUE). Non-admins get back an empty list (or
+ *  only their own reports via the additive select_own policy). */
+export interface AdminReport extends MyReport {
+  reporterName: string | null;
+  reporterUsername: string | null;
+  targetAuthorName: string | null;
+  targetAuthorUsername: string | null;
+  postId: string | null;
+  commentId: string | null;
+  /** For a comment report, the post that holds the thread the
+   *  comment lives in — used by the "Open thread" link. */
+  commentPostId: string | null;
+}
+
+export async function fetchAllReports(): Promise<AdminReport[]> {
+  const { data, error } = await supabase
+    .from("feed_reports")
+    .select(
+      `id, reason, created_at, post_id, comment_id, status,
+       reporter:profiles_public!feed_reports_reporter_id_fkey ( name, username ),
+       post:feed_posts!feed_reports_post_id_fkey
+         ( title, author:profiles_public!feed_posts_user_id_fkey ( name, username ) ),
+       comment:feed_comments!feed_reports_comment_id_fkey
+         ( body, post_id, author:profiles_public!feed_comments_user_id_fkey ( name, username ) )`,
+    )
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  const one = <T,>(v: T | T[] | null): T | null =>
+    Array.isArray(v) ? (v[0] ?? null) : v;
+  type ActorEmbed = { name: string; username: string | null };
+  const rows = (data ?? []) as unknown as {
+    id: string;
+    reason: string | null;
+    created_at: string;
+    post_id: string | null;
+    comment_id: string | null;
+    status: string | null;
+    reporter: ActorEmbed | ActorEmbed[] | null;
+    post:
+      | {
+          title: string;
+          author: ActorEmbed | ActorEmbed[] | null;
+        }
+      | {
+          title: string;
+          author: ActorEmbed | ActorEmbed[] | null;
+        }[]
+      | null;
+    comment:
+      | {
+          body: string;
+          post_id: string;
+          author: ActorEmbed | ActorEmbed[] | null;
+        }
+      | {
+          body: string;
+          post_id: string;
+          author: ActorEmbed | ActorEmbed[] | null;
+        }[]
+      | null;
+  }[];
+  return rows.map((r) => {
+    const reporter = one(r.reporter);
+    const post = one(r.post);
+    const comment = one(r.comment);
+    const author = one(post?.author ?? comment?.author ?? null);
+    return {
+      id: r.id,
+      reason: r.reason,
+      createdAt: r.created_at,
+      target: r.post_id ? ("post" as const) : ("comment" as const),
+      targetLabel: post?.title ?? comment?.body ?? null,
+      status: ((r.status ?? "open") as ReportStatus),
+      reporterName: reporter?.name ?? null,
+      reporterUsername: reporter?.username ?? null,
+      targetAuthorName: author?.name ?? null,
+      targetAuthorUsername: author?.username ?? null,
+      postId: r.post_id,
+      commentId: r.comment_id,
+      commentPostId: comment?.post_id ?? null,
+    };
+  });
+}
+
+/** Admin: change a report's moderation status. Gated server-side by
+ *  the `feed_reports_update_admin` RLS policy — non-admins get a 403. */
+export async function setReportStatus(
+  reportId: string,
+  status: ReportStatus,
+): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const resolving = status !== "open";
+  await supabase
+    .from("feed_reports")
+    .update({
+      status,
+      reviewed_at: resolving ? new Date().toISOString() : null,
+      reviewed_by: resolving ? (user?.id ?? null) : null,
+    })
+    .eq("id", reportId);
 }
 
 /** Sets the current user's vote on a comment. dir 0 clears it. */
@@ -444,7 +555,11 @@ export async function fetchFollowing(): Promise<string[]> {
   return (data ?? []).map((r) => (r as { followee_id: string }).followee_id);
 }
 
-/** Follows/unfollows a profile; returns the new following state. */
+/** Follows/unfollows a profile; returns the new following state.
+ *  Refuses to create the tie if either side has blocked the other —
+ *  server-side it'd be possible to insert one (the RLS policies don't
+ *  cross-reference feed_blocks), so this guard is the only thing
+ *  preventing a silent "blocked but still followable" state. */
 export async function toggleFollow(followeeId: string): Promise<boolean> {
   const {
     data: { user },
@@ -463,6 +578,17 @@ export async function toggleFollow(followeeId: string): Promise<boolean> {
       .eq("follower_id", user.id)
       .eq("followee_id", followeeId);
     return false;
+  }
+  const { data: block } = await supabase
+    .from("feed_blocks")
+    .select("blocker_id")
+    .or(
+      `and(blocker_id.eq.${user.id},blocked_id.eq.${followeeId}),` +
+        `and(blocker_id.eq.${followeeId},blocked_id.eq.${user.id})`,
+    )
+    .maybeSingle();
+  if (block) {
+    throw new Error("Unblock this person before following them.");
   }
   await supabase
     .from("feed_follows")
@@ -483,9 +609,24 @@ export async function fetchBlocked(): Promise<string[]> {
   return (data ?? []).map((r) => (r as { blocked_id: string }).blocked_id);
 }
 
-/** Blocked profiles with display names — for the Settings list. */
+/** Profile ids of users who blocked the current user — needed to
+ *  filter them out of suggestions / follower lists so the blocker's
+ *  account isn't surfaced to someone they don't want contact with. */
+export async function fetchBlockedBy(): Promise<string[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+  const { data } = await supabase
+    .from("feed_blocks")
+    .select("blocker_id")
+    .eq("blocked_id", user.id);
+  return (data ?? []).map((r) => (r as { blocker_id: string }).blocker_id);
+}
+
+/** Blocked profiles with display names + avatars — for the Settings list. */
 export async function fetchBlockedProfiles(): Promise<
-  { id: string; name: string }[]
+  { id: string; name: string; avatarUrl: string | null }[]
 > {
   const {
     data: { user },
@@ -494,7 +635,7 @@ export async function fetchBlockedProfiles(): Promise<
   const { data } = await supabase
     .from("feed_blocks")
     .select(
-      "blocked:profiles_public!feed_blocks_blocked_id_fkey ( id, name )",
+      "blocked:profiles_public!feed_blocks_blocked_id_fkey ( id, name, avatar_url )",
     )
     .eq("blocker_id", user.id);
   const rows = (data ?? []) as unknown as {
@@ -503,10 +644,14 @@ export async function fetchBlockedProfiles(): Promise<
   return rows
     .map((r) => (Array.isArray(r.blocked) ? r.blocked[0] : r.blocked))
     .filter((p): p is ProfileEmbed => !!p)
-    .map((p) => ({ id: p.id, name: p.name }));
+    .map((p) => ({ id: p.id, name: p.name, avatarUrl: p.avatar_url }));
 }
 
-/** Blocks a profile — also drops any follow so the tie is fully cut. */
+/** Blocks a profile — also drops any follow tie so neither side keeps
+ *  a stale connection. Their follow on you is just as wrong as yours
+ *  on them after a block; the OR filter expresses both at once and
+ *  RLS (widened in 20260523030000_feed_follows_followee_delete) allows
+ *  both rows to be deleted. */
 export async function blockUser(blockedId: string): Promise<void> {
   const {
     data: { user },
@@ -521,8 +666,10 @@ export async function blockUser(blockedId: string): Promise<void> {
   await supabase
     .from("feed_follows")
     .delete()
-    .eq("follower_id", user.id)
-    .eq("followee_id", blockedId);
+    .or(
+      `and(follower_id.eq.${user.id},followee_id.eq.${blockedId}),` +
+        `and(follower_id.eq.${blockedId},followee_id.eq.${user.id})`,
+    );
 }
 
 export async function unblockUser(blockedId: string): Promise<void> {
@@ -655,4 +802,138 @@ export async function fetchMyCommentVotes(): Promise<Record<string, number>> {
     out[row.comment_id] = row.value;
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Server notifications (feed_notifications)
+// ---------------------------------------------------------------------------
+
+/** One of: follow, comment_on_post, reply_to_comment, friend_post,
+ *  post_upvote, comment_upvote — matches the Postgres
+ *  `feed_notification_kind` enum exactly. A new server value the
+ *  client doesn't render yet falls through to a generic card. */
+export type FeedNotificationKind =
+  | "follow"
+  | "comment_on_post"
+  | "reply_to_comment"
+  | "friend_post"
+  | "post_upvote"
+  | "comment_upvote";
+
+export interface FeedNotification {
+  id: string;
+  kind: FeedNotificationKind | string;
+  createdAt: string;
+  readAt: string | null;
+  actorId: string | null;
+  actorName: string;
+  actorAvatarUrl: string | null;
+  postId: string | null;
+  commentId: string | null;
+  postTitle: string | null;
+  commentBody: string | null;
+}
+
+/** The current user's notification feed — newest first, capped at 100.
+ *  Reads via the `feed_notifications_select_own` RLS policy. */
+export async function fetchNotifications(): Promise<FeedNotification[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+  const { data, error } = await supabase
+    .from("feed_notifications")
+    .select(
+      `id, kind, created_at, read_at, post_id, comment_id,
+       actor:profiles_public!feed_notifications_actor_id_fkey ( id, name, avatar_url ),
+       post:feed_posts!feed_notifications_post_id_fkey ( title ),
+       comment:feed_comments!feed_notifications_comment_id_fkey ( body )`,
+    )
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+    .limit(100);
+  if (error) throw error;
+  type ActorEmbed = {
+    id: string;
+    name: string;
+    avatar_url: string | null;
+  };
+  const rows = (data ?? []) as unknown as {
+    id: string;
+    kind: string;
+    created_at: string;
+    read_at: string | null;
+    post_id: string | null;
+    comment_id: string | null;
+    actor: ActorEmbed | ActorEmbed[] | null;
+    post: { title: string } | { title: string }[] | null;
+    comment: { body: string } | { body: string }[] | null;
+  }[];
+  const one = <T,>(v: T | T[] | null): T | null =>
+    Array.isArray(v) ? (v[0] ?? null) : v;
+  return rows.map((r) => {
+    const actor = one(r.actor);
+    const post = one(r.post);
+    const comment = one(r.comment);
+    return {
+      id: r.id,
+      kind: r.kind,
+      createdAt: r.created_at,
+      readAt: r.read_at,
+      actorId: actor?.id ?? null,
+      actorName: actor?.name ?? "Someone",
+      actorAvatarUrl: actor?.avatar_url ?? null,
+      postId: r.post_id,
+      commentId: r.comment_id,
+      postTitle: post?.title ?? null,
+      commentBody: comment?.body ?? null,
+    };
+  });
+}
+
+export async function markNotificationRead(id: string): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("feed_notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("user_id", user.id);
+}
+
+export async function markAllNotificationsRead(): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("feed_notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("user_id", user.id)
+    .is("read_at", null);
+}
+
+export async function deleteNotification(id: string): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("feed_notifications")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+}
+
+export async function clearAllNotifications(): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("feed_notifications")
+    .delete()
+    .eq("user_id", user.id);
 }

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -655,6 +655,73 @@ export async function setReaction(args: {
   );
 }
 
+export interface FollowingProfile {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+}
+
+/** Profiles the current user follows, newest follow first — drives
+ *  the "Send to a friend" picker. Auth-gated by the caller; returns
+ *  [] when not signed in. */
+export async function fetchMyFollowingProfiles(): Promise<FollowingProfile[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+  type Row = {
+    created_at: string;
+    followee: { id: string; name: string | null; avatar_url: string | null } | null;
+  };
+  const { data } = await supabase
+    .from("feed_follows")
+    .select(
+      "created_at, " +
+        "followee:profiles_public!feed_follows_followee_id_fkey ( id, name, avatar_url )",
+    )
+    .eq("follower_id", user.id)
+    .order("created_at", { ascending: false });
+  const out: FollowingProfile[] = [];
+  for (const r of (data ?? []) as unknown as Row[]) {
+    const p = r.followee;
+    if (!p?.id) continue;
+    out.push({
+      id: p.id,
+      name: p.name ?? "Someone",
+      avatarUrl: p.avatar_url,
+    });
+  }
+  return out;
+}
+
+/** Sends `postId` to `recipientId` as a "have you read this" pick.
+ *  Inserts into feed_pick_sends — the AFTER-INSERT trigger fires
+ *  the 'pick_sent' notification on the recipient's inbox; RLS
+ *  guards the sender_id check. `message` is the optional one-liner
+ *  shown to the recipient. */
+export async function sendPickToFriend(args: {
+  postId: string;
+  recipientId: string;
+  message?: string;
+}): Promise<void> {
+  const { postId, recipientId, message } = args;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not signed in");
+  if (user.id === recipientId) {
+    throw new Error("Can't send a pick to yourself");
+  }
+  const trimmed = message?.trim() ?? "";
+  const { error } = await supabase.from("feed_pick_sends").insert({
+    sender_id: user.id,
+    recipient_id: recipientId,
+    post_id: postId,
+    message: trimmed.length > 0 ? trimmed : null,
+  });
+  if (error) throw error;
+}
+
 export interface SearchProfileResult {
   id: string;
   name: string;

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -542,6 +542,119 @@ export async function fetchMyPostVotes(): Promise<Record<string, number>> {
   return out;
 }
 
+/** Set of emoji users can react with — mirrors the CHECK constraint
+ *  in 20260524000000_feed_reactions.sql. Order is the picker order. */
+export const REACTION_EMOJI = [
+  "❤️",
+  "🔥",
+  "😂",
+  "😢",
+  "🤔",
+  "👏",
+] as const;
+export type ReactionEmoji = (typeof REACTION_EMOJI)[number];
+
+export type ReactionTargetKind = "post" | "comment";
+
+export interface ReactionAggregates {
+  /** counts[targetId][emoji] = N */
+  counts: Record<string, Partial<Record<ReactionEmoji, number>>>;
+  /** mine[targetId] = the single emoji the current user picked. */
+  mine: Record<string, ReactionEmoji>;
+}
+
+/** Aggregated reactions for the given post + comment ids — one
+ *  query per kind because target_kind is part of the index. Returns
+ *  empty maps when neither id list is provided. */
+export async function fetchReactions(args: {
+  postIds?: string[];
+  commentIds?: string[];
+}): Promise<ReactionAggregates> {
+  const { postIds = [], commentIds = [] } = args;
+  if (postIds.length === 0 && commentIds.length === 0) {
+    return { counts: {}, mine: {} };
+  }
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const uid = user?.id ?? null;
+  type ReactionRow = {
+    user_id: string;
+    target_id: string;
+    emoji: string;
+  };
+  const queries: Promise<ReactionRow[]>[] = [];
+  if (postIds.length > 0) {
+    queries.push(
+      (async () => {
+        const { data } = await supabase
+          .from("feed_reactions")
+          .select("user_id, target_id, emoji")
+          .eq("target_kind", "post")
+          .in("target_id", postIds);
+        return (data ?? []) as ReactionRow[];
+      })(),
+    );
+  }
+  if (commentIds.length > 0) {
+    queries.push(
+      (async () => {
+        const { data } = await supabase
+          .from("feed_reactions")
+          .select("user_id, target_id, emoji")
+          .eq("target_kind", "comment")
+          .in("target_id", commentIds);
+        return (data ?? []) as ReactionRow[];
+      })(),
+    );
+  }
+  const batches = await Promise.all(queries);
+  const counts: ReactionAggregates["counts"] = {};
+  const mine: ReactionAggregates["mine"] = {};
+  for (const rows of batches) {
+    for (const r of rows) {
+      const e = r.emoji as ReactionEmoji;
+      const bucket = (counts[r.target_id] ??= {});
+      bucket[e] = (bucket[e] ?? 0) + 1;
+      if (uid && r.user_id === uid) mine[r.target_id] = e;
+    }
+  }
+  return { counts, mine };
+}
+
+/** Sets the current user's reaction on a post or comment. A null
+ *  `emoji` clears it (delete). One reaction per (user, target) is
+ *  enforced by the PK — upsert replaces a previous pick. */
+export async function setReaction(args: {
+  targetKind: ReactionTargetKind;
+  targetId: string;
+  emoji: ReactionEmoji | null;
+}): Promise<void> {
+  const { targetKind, targetId, emoji } = args;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not signed in");
+  if (emoji === null) {
+    await supabase
+      .from("feed_reactions")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("target_kind", targetKind)
+      .eq("target_id", targetId);
+    return;
+  }
+  await supabase.from("feed_reactions").upsert(
+    {
+      user_id: user.id,
+      target_kind: targetKind,
+      target_id: targetId,
+      emoji,
+    },
+    { onConflict: "user_id,target_kind,target_id" },
+  );
+}
+
 /** Looks up a profile id from a `@handle` (case-insensitive).
  *  Backs the @mention tap-handler in [MentionText]; returns `null`
  *  when the handle doesn't exist (don't throw — the UI shows a

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -655,6 +655,24 @@ export async function setReaction(args: {
   );
 }
 
+/** Whether the current user has the staff/admin bit set on their
+ *  profile. profiles_public doesn't expose is_admin (the view would
+ *  leak staff status to everyone), so this reads from the owner-only
+ *  `profiles` row. Returns false for signed-out callers. */
+export async function fetchIsAdmin(): Promise<boolean> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return false;
+  const { data } = await supabase
+    .from("profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .maybeSingle();
+  return ((data as { is_admin: boolean | null } | null)?.is_admin ?? false) ===
+    true;
+}
+
 export interface FollowingProfile {
   id: string;
   name: string;

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -53,13 +53,16 @@ interface PostRow {
   feed_comments: CommentRow[];
 }
 
+// Joins go through profiles_public (public-safe projection) because
+// the base `profiles` table has owner-only RLS. See
+// supabase/migrations/20260522040000_profiles_public_view.sql.
 const POST_SELECT = `
   id, community, activity, title, body, poster_url, creator, year,
   rating, base_score, created_at,
-  author:profiles!feed_posts_user_id_fkey ( id, name, avatar_url ),
+  author:profiles_public!feed_posts_user_id_fkey ( id, name, avatar_url ),
   feed_comments (
     id, body, parent_id, created_at, edited_at,
-    author:profiles!feed_comments_user_id_fkey ( id, name, avatar_url )
+    author:profiles_public!feed_comments_user_id_fkey ( id, name, avatar_url )
   )
 `;
 
@@ -490,7 +493,9 @@ export async function fetchBlockedProfiles(): Promise<
   if (!user) return [];
   const { data } = await supabase
     .from("feed_blocks")
-    .select("blocked:profiles!feed_blocks_blocked_id_fkey ( id, name )")
+    .select(
+      "blocked:profiles_public!feed_blocks_blocked_id_fkey ( id, name )",
+    )
     .eq("blocker_id", user.id);
   const rows = (data ?? []) as unknown as {
     blocked: ProfileEmbed | ProfileEmbed[] | null;
@@ -581,7 +586,7 @@ export async function fetchProfile(profileId: string): Promise<{
   tags: string[];
 } | null> {
   const { data } = await supabase
-    .from("profiles")
+    .from("profiles_public")
     .select("id, name, avatar_url, bio, interests, tags")
     .eq("id", profileId)
     .maybeSingle();

--- a/src/features/feed/feed-service.ts
+++ b/src/features/feed/feed-service.ts
@@ -542,6 +542,23 @@ export async function fetchMyPostVotes(): Promise<Record<string, number>> {
   return out;
 }
 
+/** Looks up a profile id from a `@handle` (case-insensitive).
+ *  Backs the @mention tap-handler in [MentionText]; returns `null`
+ *  when the handle doesn't exist (don't throw — the UI shows a
+ *  toast in that case). */
+export async function resolveUsernameToId(
+  username: string,
+): Promise<string | null> {
+  const handle = username.replace(/^@/, "").trim();
+  if (!handle) return null;
+  const { data } = await supabase
+    .from("profiles_public")
+    .select("id")
+    .ilike("username", handle)
+    .maybeSingle();
+  return (data as { id: string } | null)?.id ?? null;
+}
+
 /** Profile ids the current user follows. */
 export async function fetchFollowing(): Promise<string[]> {
   const {

--- a/src/features/feed/mention-text.tsx
+++ b/src/features/feed/mention-text.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { resolveUsernameToId } from "./feed-service";
+
+/** Matches `@handle` only when it starts the body or follows
+ *  whitespace — keeps emails (foo@bar.com) and double-@ from being
+ *  rendered as mentions. Handles are [A-Za-z0-9_], 1-32 chars. */
+const MENTION_RE = /(^|\s)@([A-Za-z0-9_]{1,32})/g;
+
+/** Renders a comment / post body with `@username` mentions styled as
+ *  tappable violet spans. Tap resolves the handle to a profile id and
+ *  routes to `/feed/u/<id>`, or shows a "not found" toast.
+ *
+ *  Drop-in for `{body}` — keeps the surrounding `<p>` tag with its
+ *  current text styling; only the mention spans diverge in color. */
+export function MentionText({ body }: { body: string }) {
+  const router = useRouter();
+
+  MENTION_RE.lastIndex = 0;
+  const parts: Array<string | { handle: string; key: string }> = [];
+  let cursor = 0;
+  let i = 0;
+  for (const m of body.matchAll(MENTION_RE)) {
+    const lead = m[1] ?? "";
+    const handle = m[2]!;
+    const start = (m.index ?? 0) + lead.length;
+    if (start > cursor) parts.push(body.slice(cursor, start));
+    parts.push({ handle, key: `${start}-${i++}` });
+    cursor = (m.index ?? 0) + m[0].length;
+  }
+  if (cursor < body.length) parts.push(body.slice(cursor));
+
+  // No mentions — render as a single text node so the rendered DOM
+  // is identical to plain `{body}`.
+  if (parts.every((p) => typeof p === "string")) {
+    return <>{body}</>;
+  }
+
+  return (
+    <>
+      {parts.map((p, idx) =>
+        typeof p === "string" ? (
+          <span key={idx}>{p}</span>
+        ) : (
+          <button
+            key={p.key}
+            type="button"
+            onClick={async (e) => {
+              e.stopPropagation();
+              const id = await resolveUsernameToId(p.handle);
+              if (!id) {
+                toast.error(`@${p.handle} not found.`);
+                return;
+              }
+              router.push(`/feed/u/${id}`);
+            }}
+            className="font-bold text-violet-600 hover:underline dark:text-violet-300"
+          >
+            @{p.handle}
+          </button>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/features/feed/reaction-bar.tsx
+++ b/src/features/feed/reaction-bar.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Plus } from "lucide-react";
+import { toast } from "sonner";
+
+import { useAuth } from "@/features/auth/hooks/use-auth";
+import { cn } from "@/lib/utils";
+import {
+  REACTION_EMOJI,
+  type ReactionEmoji,
+  type ReactionTargetKind,
+} from "./feed-service";
+import { useSetReaction } from "./use-feed";
+
+/** Compact reaction strip rendered under a post body or a comment.
+ *
+ *  Existing reactions show as pills (emoji + count) — the user's own
+ *  pick is tinted violet. A trailing `+` opens an inline picker of
+ *  every emoji in [REACTION_EMOJI]. Tapping the same emoji twice
+ *  clears it; tapping a different one replaces it (one reaction per
+ *  user per target, enforced by the table's PK).
+ *
+ *  `counts` / `mine` are read from the parent's `useReactions(…)`
+ *  cache so the row updates immediately after a mutation — the
+ *  mutation's onSuccess invalidates the `feed.reactions` family. */
+export function ReactionBar({
+  targetKind,
+  targetId,
+  counts,
+  mine,
+}: {
+  targetKind: ReactionTargetKind;
+  targetId: string;
+  counts: Partial<Record<ReactionEmoji, number>>;
+  mine: ReactionEmoji | null;
+}) {
+  const { session } = useAuth();
+  const setReaction = useSetReaction();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const pick = async (emoji: ReactionEmoji) => {
+    setPickerOpen(false);
+    try {
+      await setReaction.mutateAsync({
+        targetKind,
+        targetId,
+        // Tapping the emoji you already picked clears it.
+        emoji: mine === emoji ? null : emoji,
+      });
+    } catch {
+      toast.error("Couldn't save reaction.");
+    }
+  };
+
+  // Stable display order: keep REACTION_EMOJI order, only show ones
+  // that actually have a count. Anything else stays behind the `+`.
+  const pills = REACTION_EMOJI.filter((e) => (counts[e] ?? 0) > 0);
+  const canReact = !!session;
+
+  if (pills.length === 0 && !canReact) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+      {pills.map((e) => {
+        const isMine = mine === e;
+        return (
+          <button
+            key={e}
+            type="button"
+            onClick={(ev) => {
+              ev.stopPropagation();
+              if (canReact) pick(e);
+            }}
+            disabled={!canReact}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[12px] font-semibold transition-colors",
+              isMine
+                ? "border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-500/60 dark:bg-violet-500/15 dark:text-violet-200"
+                : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-slate-600",
+            )}
+          >
+            <span className="text-[13px] leading-none">{e}</span>
+            <span className="tabular-nums">{counts[e]}</span>
+          </button>
+        );
+      })}
+      {canReact && (
+        <button
+          type="button"
+          onClick={(ev) => {
+            ev.stopPropagation();
+            setPickerOpen((o) => !o);
+          }}
+          aria-label="Add reaction"
+          aria-expanded={pickerOpen}
+          className="inline-flex h-6 items-center justify-center rounded-full border border-dashed border-slate-300 px-2 text-slate-400 transition-colors hover:border-violet-300 hover:text-violet-500 dark:border-slate-600 dark:hover:border-violet-500/60 dark:hover:text-violet-300"
+        >
+          <Plus size={12} />
+        </button>
+      )}
+      <AnimatePresence>
+        {canReact && pickerOpen && (
+          <motion.div
+            key="picker"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.12, ease: "easeOut" }}
+            className="basis-full"
+          >
+            <div className="mt-1 inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white p-1 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+              {REACTION_EMOJI.map((e) => (
+                <button
+                  key={e}
+                  type="button"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    pick(e);
+                  }}
+                  className={cn(
+                    "rounded-full px-2 py-1 text-[15px] leading-none transition-transform hover:scale-110",
+                    mine === e &&
+                      "bg-violet-100 dark:bg-violet-500/20",
+                  )}
+                >
+                  {e}
+                </button>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/features/feed/send-pick-dialog.tsx
+++ b/src/features/feed/send-pick-dialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Search, Send } from "lucide-react";
+import { toast } from "sonner";
+
+import { Dialog } from "@/components/ui/dialog";
+import { FeedAvatar } from "@/features/feed/components/feed-avatar";
+import {
+  useMyFollowingProfiles,
+  useSendPick,
+} from "@/features/feed/use-feed";
+
+/** "Send to a friend" — lightweight DM that reuses the feed_pick_sends
+ *  table. Lists everyone the user follows, with an optional one-liner
+ *  above; tap a row to send. Multi-select is intentionally NOT
+ *  supported — a pick blasted to fifty people is spam, not a
+ *  recommendation. */
+export function SendPickDialog({
+  open,
+  onClose,
+  postId,
+  postTitle,
+}: {
+  open: boolean;
+  onClose: () => void;
+  postId: string;
+  postTitle: string;
+}) {
+  const { data: following = [], isLoading } = useMyFollowingProfiles();
+  const sendPick = useSendPick();
+  const [message, setMessage] = useState("");
+  const [query, setQuery] = useState("");
+  const [pending, setPending] = useState<string | null>(null);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return following;
+    return following.filter((p) => p.name.toLowerCase().includes(q));
+  }, [following, query]);
+
+  const send = async (recipientId: string, recipientName: string) => {
+    if (pending) return;
+    setPending(recipientId);
+    try {
+      await sendPick.mutateAsync({
+        postId,
+        recipientId,
+        message: message.trim() || undefined,
+      });
+      toast.success(`Sent to ${recipientName}`);
+      // Reset state so the next "Send to a friend" open is clean.
+      setMessage("");
+      setQuery("");
+      onClose();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Couldn't send — try again.",
+      );
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} size="md" ariaLabel="Send to a friend">
+      <div className="p-5">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-400">
+          Send to a friend
+        </p>
+        <h2 className="mt-1 line-clamp-2 text-lg font-black tracking-tight text-slate-800 dark:text-slate-100">
+          {postTitle}
+        </h2>
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          Tap a friend to send. They&apos;ll get a notification.
+        </p>
+
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Add a one-liner (optional)…"
+          rows={2}
+          maxLength={280}
+          className="mt-4 w-full resize-none rounded-2xl border border-slate-200 bg-slate-50 p-3 text-sm outline-none transition-colors focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-100 dark:focus:border-indigo-500"
+        />
+
+        {following.length >= 6 && (
+          <div className="relative mt-3">
+            <Search
+              size={14}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+            />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter your friends"
+              className="w-full rounded-full border border-slate-200 bg-white py-2 pl-9 pr-3 text-xs transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-900/65 dark:text-slate-100 dark:focus:border-indigo-500"
+            />
+          </div>
+        )}
+
+        <div className="mt-4 max-h-[320px] overflow-y-auto">
+          {isLoading ? (
+            <p className="px-4 py-10 text-center text-sm text-slate-400">
+              Loading your friends…
+            </p>
+          ) : following.length === 0 ? (
+            <p className="px-4 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
+              You&apos;re not following anyone yet. Add friends to send picks.
+            </p>
+          ) : visible.length === 0 ? (
+            <p className="px-4 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
+              No matches for &ldquo;{query}&rdquo;.
+            </p>
+          ) : (
+            <ul className="divide-y divide-slate-200/70 overflow-hidden rounded-2xl border border-slate-200/70 dark:divide-slate-700/60 dark:border-slate-700/60">
+              {visible.map((p) => (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    onClick={() => send(p.id, p.name)}
+                    disabled={pending !== null}
+                    className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50/60 disabled:opacity-50 sm:px-5 dark:hover:bg-slate-800/40"
+                  >
+                    <FeedAvatar
+                      name={p.name}
+                      url={p.avatarUrl ?? undefined}
+                      size={36}
+                    />
+                    <p className="min-w-0 flex-1 truncate text-sm font-black tracking-tight">
+                      {p.name}
+                    </p>
+                    <Send
+                      size={14}
+                      className="text-slate-400 dark:text-slate-500"
+                    />
+                    {pending === p.id && (
+                      <span className="text-[11px] font-semibold text-slate-400">
+                        Sending…
+                      </span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -9,6 +9,7 @@ import {
 
 import * as svc from "./feed-service";
 import type { FeedPost } from "./types";
+import { useMutedKinds } from "@/features/notifications/use-muted-kinds";
 
 /** Query keys for the feed data set — all invalidated together by id. */
 const KEYS = {
@@ -303,18 +304,33 @@ export function useSetReportStatus() {
 
 const NOTIF_KEY = ["feed", "notifications"] as const;
 
-export function useNotifications() {
+/** Raw query — every row from feed_notifications, unfiltered. Other
+ *  hooks layer the muted-kinds filter on top so the bell badge + the
+ *  inbox + the settings counter all share one source of truth. */
+function useNotificationsRaw() {
   return useQuery({
     queryKey: NOTIF_KEY,
     queryFn: svc.fetchNotifications,
   });
 }
 
-/** Unread count summed across all kinds — the navbar bell reads this
- *  instead of recomputing from the list. */
+export function useNotifications() {
+  const raw = useNotificationsRaw();
+  const { muted } = useMutedKinds();
+  const data = useMemo(() => {
+    const all = raw.data ?? [];
+    if (muted.size === 0) return all;
+    return all.filter((n) => !muted.has(n.kind));
+  }, [raw.data, muted]);
+  return { ...raw, data };
+}
+
+/** Unread count summed across all kinds the user hasn't muted — the
+ *  navbar bell reads this so muting a kind clears its contribution to
+ *  the badge immediately. */
 export function useUnreadNotificationsCount(): number {
   const { data } = useNotifications();
-  return (data ?? []).filter((n) => n.readAt === null).length;
+  return data.filter((n) => n.readAt === null).length;
 }
 
 export function useMarkNotificationRead() {

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -270,3 +270,81 @@ export function useUnblockUser() {
     onSuccess: () => qc.invalidateQueries({ queryKey: KEYS.blocked }),
   });
 }
+
+// ---------------------------------------------------------------------------
+// Reports moderation (admin)
+// ---------------------------------------------------------------------------
+
+/** Admin reports list — see [fetchAllReports]. Non-admins get an empty
+ *  array (RLS), so any non-admin landing on a moderation page just sees
+ *  the empty state. */
+export function useAllReports() {
+  return useQuery({
+    queryKey: ["feed", "all-reports"],
+    queryFn: svc.fetchAllReports,
+  });
+}
+
+export function useSetReportStatus() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (v: { reportId: string; status: svc.ReportStatus }) =>
+      svc.setReportStatus(v.reportId, v.status),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["feed", "all-reports"] });
+      qc.invalidateQueries({ queryKey: ["feed", "my-reports"] });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Notifications (feed_notifications)
+// ---------------------------------------------------------------------------
+
+const NOTIF_KEY = ["feed", "notifications"] as const;
+
+export function useNotifications() {
+  return useQuery({
+    queryKey: NOTIF_KEY,
+    queryFn: svc.fetchNotifications,
+  });
+}
+
+/** Unread count summed across all kinds — the navbar bell reads this
+ *  instead of recomputing from the list. */
+export function useUnreadNotificationsCount(): number {
+  const { data } = useNotifications();
+  return (data ?? []).filter((n) => n.readAt === null).length;
+}
+
+export function useMarkNotificationRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: svc.markNotificationRead,
+    onSuccess: () => qc.invalidateQueries({ queryKey: NOTIF_KEY }),
+  });
+}
+
+export function useMarkAllNotificationsRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: svc.markAllNotificationsRead,
+    onSuccess: () => qc.invalidateQueries({ queryKey: NOTIF_KEY }),
+  });
+}
+
+export function useDeleteNotification() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: svc.deleteNotification,
+    onSuccess: () => qc.invalidateQueries({ queryKey: NOTIF_KEY }),
+  });
+}
+
+export function useClearAllNotifications() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: svc.clearAllNotifications,
+    onSuccess: () => qc.invalidateQueries({ queryKey: NOTIF_KEY }),
+  });
+}

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -147,6 +147,13 @@ export function useReactions(args: {
   });
 }
 
+export function useFollowSuggestions() {
+  return useQuery({
+    queryKey: ["feed", "follow-suggestions"] as const,
+    queryFn: () => svc.fetchFollowSuggestions(),
+  });
+}
+
 export function useSetReaction() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -166,6 +166,15 @@ export function useSearchPosts(query: string) {
   });
 }
 
+export function useIsAdmin() {
+  return useQuery({
+    queryKey: ["feed", "is-admin"] as const,
+    queryFn: svc.fetchIsAdmin,
+    // is_admin rarely changes; keep the result warm for the session.
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
 export function useMyFollowingProfiles() {
   return useQuery({
     queryKey: ["feed", "my-following-profiles"] as const,

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -166,6 +166,19 @@ export function useSearchPosts(query: string) {
   });
 }
 
+export function useMyFollowingProfiles() {
+  return useQuery({
+    queryKey: ["feed", "my-following-profiles"] as const,
+    queryFn: svc.fetchMyFollowingProfiles,
+  });
+}
+
+export function useSendPick() {
+  return useMutation({
+    mutationFn: svc.sendPickToFriend,
+  });
+}
+
 export function useFollowSuggestions() {
   return useQuery({
     queryKey: ["feed", "follow-suggestions"] as const,

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -125,6 +125,39 @@ export function useVisibleFeed() {
   };
 }
 
+/** Batched reaction aggregates for a list of post + comment ids.
+ *  One query per kind, so passing both is cheaper than two hooks.
+ *  Keyed by sorted ids so two render passes with the same set of
+ *  ids share the same cache entry. */
+export function useReactions(args: {
+  postIds: string[];
+  commentIds?: string[];
+}) {
+  const { postIds, commentIds } = args;
+  const sortedPosts = useMemo(() => [...postIds].sort(), [postIds]);
+  const sortedComments = useMemo(
+    () => [...(commentIds ?? [])].sort(),
+    [commentIds],
+  );
+  return useQuery({
+    queryKey: ["feed", "reactions", sortedPosts, sortedComments] as const,
+    queryFn: () =>
+      svc.fetchReactions({ postIds: sortedPosts, commentIds: sortedComments }),
+    enabled: sortedPosts.length > 0 || sortedComments.length > 0,
+  });
+}
+
+export function useSetReaction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: svc.setReaction,
+    // Reactions don't carry a per-query cache key fine enough to
+    // surgically invalidate, so invalidate the whole reactions family.
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["feed", "reactions"] }),
+  });
+}
+
 /* ── mutations ────────────────────────────────────────────────────── */
 
 export function useCreatePost() {

--- a/src/features/feed/use-feed.ts
+++ b/src/features/feed/use-feed.ts
@@ -147,6 +147,25 @@ export function useReactions(args: {
   });
 }
 
+/** Live profile-search results for the given query. Caller should
+ *  debounce upstream (or accept the staleness — react-query keeps the
+ *  previous query's data while a new one loads). */
+export function useSearchProfiles(query: string) {
+  return useQuery({
+    queryKey: ["feed", "search", "profiles", query] as const,
+    queryFn: () => svc.searchProfiles(query),
+    enabled: query.trim().length >= 2,
+  });
+}
+
+export function useSearchPosts(query: string) {
+  return useQuery({
+    queryKey: ["feed", "search", "posts", query] as const,
+    queryFn: () => svc.searchPosts(query),
+    enabled: query.trim().length >= 2,
+  });
+}
+
 export function useFollowSuggestions() {
   return useQuery({
     queryKey: ["feed", "follow-suggestions"] as const,

--- a/src/features/notifications/use-muted-kinds.ts
+++ b/src/features/notifications/use-muted-kinds.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Per-device set of muted server-notification kinds. We default to
+ * "everything on" — an empty set — so existing installs pick up new
+ * kinds without the user having to discover the toggle. Stored as a
+ * comma-separated string under `smart_advisor_notif_muted_kinds`, with
+ * the same sync pattern as [useFeedVisibility]: `storage` for other
+ * tabs + a custom event for same-tab updates.
+ *
+ * Read by [useNotifications] / [useUnreadNotificationsCount] / the
+ * notifications bell so muted kinds are filtered out everywhere with
+ * one source of truth.
+ */
+export const PREF_MUTED_KINDS_KEY = "smart_advisor_notif_muted_kinds";
+
+const MUTED_KINDS_EVENT = "smart-advisor:notif-muted-kinds-change";
+
+export function readMutedKinds(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  const raw = window.localStorage.getItem(PREF_MUTED_KINDS_KEY) ?? "";
+  if (raw.length === 0) return new Set();
+  return new Set(raw.split(","));
+}
+
+function writeMutedKinds(next: Set<string>): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    PREF_MUTED_KINDS_KEY,
+    Array.from(next).join(","),
+  );
+  window.dispatchEvent(new Event(MUTED_KINDS_EVENT));
+}
+
+export function useMutedKinds(): {
+  muted: Set<string>;
+  isMuted: (kind: string) => boolean;
+  setMuted: (kind: string, muted: boolean) => void;
+} {
+  // Start empty so SSR and first client render agree; the real value
+  // is hydrated in the effect.
+  const [muted, setLocal] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    const sync = () => setLocal(readMutedKinds());
+    sync();
+    window.addEventListener("storage", sync);
+    window.addEventListener(MUTED_KINDS_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(MUTED_KINDS_EVENT, sync);
+    };
+  }, []);
+
+  const setMuted = useCallback((kind: string, isMuted: boolean) => {
+    const next = readMutedKinds();
+    if (isMuted) next.add(kind);
+    else next.delete(kind);
+    writeMutedKinds(next);
+    setLocal(next);
+  }, []);
+
+  const isMuted = useCallback((kind: string) => muted.has(kind), [muted]);
+
+  return { muted, isMuted, setMuted };
+}

--- a/supabase/migrations/20260522040000_profiles_public_view.sql
+++ b/supabase/migrations/20260522040000_profiles_public_view.sql
@@ -1,0 +1,48 @@
+-- =============================================================
+-- profiles_public: cross-account safe projection
+-- =============================================================
+-- The canonical `profiles_select` policy is owner-only (auth.uid()
+-- = id). That means embeds like `author:profiles(...)` from
+-- feed_posts / feed_comments return NULL for any profile other
+-- than your own — and that cascades into "Someone" display names,
+-- empty author IDs (which then break isOwn checks on the
+-- three-dot menu and hide Edit/Delete on your own posts when the
+-- viewer comes from another account), and a "post isn't
+-- available" deep-link fallback. The same RLS subquery breaks
+-- public-library visibility (`p.library_public = TRUE` EXISTS
+-- check filters to own rows only).
+--
+-- Fix: expose only the public-safe columns via a view that
+-- bypasses the underlying RLS (security_invoker = false runs the
+-- view's query as the view OWNER, which has unrestricted SELECT
+-- on the base table). Sensitive columns (email, age,
+-- backup_email, content_tone in some product contexts) stay
+-- locked behind the existing owner-only policy on the base
+-- `profiles` table.
+--
+-- Embeds in client code switch from `profiles` to
+-- `profiles_public`; PostgREST retains FK relationships for
+-- single-table views so `author:profiles_public!feed_posts_user_id_fkey`
+-- continues to resolve.
+
+CREATE OR REPLACE VIEW public.profiles_public
+WITH (security_invoker = false)
+AS SELECT
+  id,
+  name,
+  username,
+  avatar_url,
+  bio,
+  interests,
+  tags,
+  library_public,
+  created_at
+FROM public.profiles;
+
+GRANT SELECT ON public.profiles_public TO authenticated, anon;
+
+COMMENT ON VIEW public.profiles_public IS
+  'Public-safe projection of profiles for cross-account reads '
+  '(feed authors, follower lists, profile pages, public-library '
+  'visibility). Excludes email, age, backup_email and any other '
+  'PII columns that should stay owner-only on the base table.';

--- a/supabase/migrations/20260523000000_feed_reports_readable_view.sql
+++ b/supabase/migrations/20260523000000_feed_reports_readable_view.sql
@@ -1,0 +1,55 @@
+-- =============================================================
+-- feed_reports_readable: human-readable join over feed_reports
+-- =============================================================
+-- The raw feed_reports table is a forest of UUIDs (reporter_id,
+-- post_id, comment_id), so triaging by hand in the Supabase
+-- dashboard is painful. This view joins in usernames and the
+-- post/comment body so a single SELECT tells you who reported
+-- what, why, and what the offending content actually says.
+--
+-- Visibility: no GRANT to authenticated or anon, so only the
+-- service role (Supabase dashboard / SQL editor) can read it.
+-- Reports themselves stay write-only for end users via the
+-- existing RLS on the base table; this view doesn't widen
+-- anything, it just decodes the IDs the dashboard already sees.
+
+CREATE OR REPLACE VIEW public.feed_reports_readable
+WITH (security_invoker = false)
+AS SELECT
+  r.id,
+  r.created_at,
+  r.reason,
+  reporter.username     AS reporter,
+  reporter.name         AS reporter_name,
+  -- Post target (NULL when the report is on a comment).
+  p.title               AS post_title,
+  p.body                AS post_body,
+  p.community           AS post_community,
+  post_author.username  AS post_author,
+  -- Comment target (NULL when the report is on a post).
+  c.body                AS comment_body,
+  cp.title              AS comment_on_post_title,
+  comment_author.username AS comment_author,
+  -- Original IDs kept around so you can jump back to the raw row.
+  r.post_id,
+  r.comment_id,
+  r.reporter_id
+FROM public.feed_reports r
+LEFT JOIN public.profiles      reporter       ON reporter.id       = r.reporter_id
+LEFT JOIN public.feed_posts    p              ON p.id              = r.post_id
+LEFT JOIN public.profiles      post_author    ON post_author.id    = p.user_id
+LEFT JOIN public.feed_comments c              ON c.id              = r.comment_id
+LEFT JOIN public.feed_posts    cp             ON cp.id             = c.post_id
+LEFT JOIN public.profiles      comment_author ON comment_author.id = c.user_id
+ORDER BY r.created_at DESC;
+
+-- Defence in depth: explicitly strip any inherited privileges so
+-- the view cannot be queried by clients even if default grants
+-- on `public` ever change.
+REVOKE ALL ON public.feed_reports_readable FROM PUBLIC;
+REVOKE ALL ON public.feed_reports_readable FROM authenticated, anon;
+
+COMMENT ON VIEW public.feed_reports_readable IS
+  'Service-role-only triage view: feed_reports joined with reporter '
+  'and target (post or comment) so dashboard rows are readable at a '
+  'glance. No client GRANT — base table RLS is unchanged.';

--- a/supabase/migrations/20260523010000_admin_reports.sql
+++ b/supabase/migrations/20260523010000_admin_reports.sql
@@ -1,0 +1,40 @@
+-- =============================================================
+-- profiles.is_admin + admin-readable feed_reports
+-- =============================================================
+-- Adds a single staff flag on profiles so a small in-app
+-- moderation surface (Settings → Reports) can read the otherwise
+-- write-only feed_reports table. End users still cannot read
+-- anyone else's reports — only rows where they are the reporter
+-- (via the pre-existing feed_reports_select_own policy) or rows
+-- they can see because they're flagged is_admin.
+--
+-- Bootstrapping: the column defaults to FALSE. To grant yourself
+-- admin, run from the Supabase SQL editor (service role bypasses
+-- the column REVOKE below):
+--     UPDATE profiles SET is_admin = TRUE WHERE email = '<you>';
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Defence in depth: clients absolutely must not be able to elevate
+-- themselves. The existing "profiles_update" policy allows owners
+-- to UPDATE their own row, but column-level REVOKE means an
+-- `UPDATE profiles SET is_admin = TRUE` from a client errors out
+-- before any policy is even evaluated. Only the service role can
+-- write the column.
+REVOKE UPDATE (is_admin) ON public.profiles FROM authenticated, anon;
+
+-- Admins may read every report (used by the in-app Reports
+-- screen). The owner-only feed_reports_select_own policy stays —
+-- the two are additive (a row is visible if either matches).
+CREATE POLICY "feed_reports_select_admin" ON public.feed_reports
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin
+  ));
+
+COMMENT ON COLUMN public.profiles.is_admin IS
+  'Staff flag. Server-write-only (column-level REVOKE on '
+  'authenticated). Unlocks the in-app Reports moderation screen '
+  'and the feed_reports_select_admin RLS policy.';

--- a/supabase/migrations/20260523020000_feed_reports_status.sql
+++ b/supabase/migrations/20260523020000_feed_reports_status.sql
@@ -1,0 +1,35 @@
+-- =============================================================
+-- feed_reports moderation status + admin UPDATE policy
+-- =============================================================
+-- Adds a status field so the in-app Reports moderation screen
+-- can mark each report as reviewed (legit, action taken) or
+-- dismissed (not actionable), and stamp who closed it. The
+-- existing select_admin policy already lets admins read every
+-- report; this migration adds the matching UPDATE policy.
+
+ALTER TABLE public.feed_reports
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'reviewed', 'dismissed')),
+  ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS reviewed_by UUID
+    REFERENCES public.profiles (id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS feed_reports_status_created_idx
+  ON public.feed_reports (status, created_at DESC);
+
+-- Only admins can resolve a report.
+CREATE POLICY "feed_reports_update_admin" ON public.feed_reports
+  FOR UPDATE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin
+  ));
+
+COMMENT ON COLUMN public.feed_reports.status IS
+  'Moderation triage state: open (default) | reviewed (action taken) '
+  '| dismissed (not actionable). Set by admins via the in-app Reports '
+  'screen — feed_reports_update_admin RLS gates the write.';

--- a/supabase/migrations/20260523030000_feed_follows_followee_delete.sql
+++ b/supabase/migrations/20260523030000_feed_follows_followee_delete.sql
@@ -1,0 +1,24 @@
+-- =============================================================
+-- feed_follows: let the followee delete a follow tie too
+-- =============================================================
+-- The original DELETE policy only permitted the follower to remove
+-- their own follow, which meant blocking severed only one direction
+-- (blocker → blocked). The reverse row (blocked still follows the
+-- blocker) was silently kept, leaving the blocker's posts visible in
+-- the blocked user's feed via the friends scope.
+--
+-- Widening the delete policy to "follower OR followee" lets blockUser
+-- cut both directions in a single OR-filtered DELETE, and also gives
+-- users a normal "remove follower" capability — a follower row is by
+-- definition shared state between the two profiles, so either party
+-- being able to drop it matches user expectations.
+
+DROP POLICY IF EXISTS "feed_follows_delete" ON public.feed_follows;
+
+CREATE POLICY "feed_follows_delete" ON public.feed_follows
+  FOR DELETE TO authenticated
+  USING (auth.uid() = follower_id OR auth.uid() = followee_id);
+
+COMMENT ON POLICY "feed_follows_delete" ON public.feed_follows IS
+  'Either party of a follow tie can drop it. Lets blockUser sever both '
+  'directions and gives followees a "remove follower" action.';

--- a/supabase/migrations/20260523040000_feed_notifications.sql
+++ b/supabase/migrations/20260523040000_feed_notifications.sql
@@ -1,0 +1,213 @@
+-- =============================================================
+-- feed_notifications + triggers
+-- =============================================================
+-- A per-user notification feed for the social side of the app —
+-- new followers, comments on your posts, replies to your comments,
+-- posts from people you follow, and upvotes on your content. Rows
+-- are inserted by AFTER-INSERT triggers on the source tables so the
+-- mobile client only needs to read this one table (polled on app
+-- resume; we deliberately don't subscribe via Realtime — see the
+-- "No Supabase Realtime" project memory).
+--
+-- Each trigger skips notifying the actor about their own action and
+-- respects the block graph in both directions (no notification if
+-- either side has blocked the other).
+
+CREATE TYPE public.feed_notification_kind AS ENUM (
+  'follow',
+  'comment_on_post',
+  'reply_to_comment',
+  'friend_post',
+  'post_upvote',
+  'comment_upvote'
+);
+
+CREATE TABLE public.feed_notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  actor_id UUID REFERENCES public.profiles (id) ON DELETE CASCADE,
+  kind public.feed_notification_kind NOT NULL,
+  post_id UUID REFERENCES public.feed_posts (id) ON DELETE CASCADE,
+  comment_id UUID REFERENCES public.feed_comments (id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  read_at TIMESTAMPTZ
+);
+
+CREATE INDEX feed_notifications_user_created_idx
+  ON public.feed_notifications (user_id, created_at DESC);
+CREATE INDEX feed_notifications_user_unread_idx
+  ON public.feed_notifications (user_id)
+  WHERE read_at IS NULL;
+
+ALTER TABLE public.feed_notifications ENABLE ROW LEVEL SECURITY;
+
+-- Recipients can read their own notifications and mark them read.
+-- Inserts come from SECURITY DEFINER trigger functions; clients can't
+-- insert directly. Deletes are allowed so the inbox "Clear" works.
+CREATE POLICY "feed_notifications_select_own" ON public.feed_notifications
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+CREATE POLICY "feed_notifications_update_own" ON public.feed_notifications
+  FOR UPDATE TO authenticated USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "feed_notifications_delete_own" ON public.feed_notifications
+  FOR DELETE TO authenticated USING (auth.uid() = user_id);
+
+-- ── Helpers ────────────────────────────────────────────────────────
+
+-- Returns TRUE when there is a block between `a` and `b` in either
+-- direction — used everywhere we'd otherwise notify across a block.
+CREATE OR REPLACE FUNCTION public._feed_either_blocks(a UUID, b UUID)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.feed_blocks
+    WHERE (blocker_id = a AND blocked_id = b)
+       OR (blocker_id = b AND blocked_id = a)
+  );
+$$;
+
+-- Single insert path so trigger bodies stay readable. Skips self
+-- notifications (no point telling you what you just did) and any
+-- pair where a block exists either way.
+CREATE OR REPLACE FUNCTION public._feed_notify(
+  recipient UUID,
+  actor UUID,
+  kind public.feed_notification_kind,
+  post UUID,
+  comment UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF recipient IS NULL OR recipient = actor THEN
+    RETURN;
+  END IF;
+  IF actor IS NOT NULL AND public._feed_either_blocks(recipient, actor) THEN
+    RETURN;
+  END IF;
+  INSERT INTO public.feed_notifications
+    (user_id, actor_id, kind, post_id, comment_id)
+  VALUES (recipient, actor, kind, post, comment);
+END;
+$$;
+
+-- ── Triggers ───────────────────────────────────────────────────────
+
+-- New follower → notify followee.
+CREATE OR REPLACE FUNCTION public._feed_notify_on_follow()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+BEGIN
+  PERFORM public._feed_notify(
+    NEW.followee_id, NEW.follower_id, 'follow', NULL, NULL);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feed_notify_on_follow
+  AFTER INSERT ON public.feed_follows
+  FOR EACH ROW EXECUTE FUNCTION public._feed_notify_on_follow();
+
+-- Comment on a post or reply to another comment → notify post owner,
+-- and (when parent_id is set) the parent comment's author too.
+CREATE OR REPLACE FUNCTION public._feed_notify_on_comment()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  post_owner UUID;
+  parent_author UUID;
+BEGIN
+  SELECT user_id INTO post_owner FROM public.feed_posts WHERE id = NEW.post_id;
+  PERFORM public._feed_notify(
+    post_owner, NEW.user_id, 'comment_on_post', NEW.post_id, NEW.id);
+
+  IF NEW.parent_id IS NOT NULL THEN
+    SELECT user_id INTO parent_author
+      FROM public.feed_comments WHERE id = NEW.parent_id;
+    -- Skip the second notification when the parent author is the
+    -- post owner (we just notified them once already).
+    IF parent_author IS NOT NULL AND parent_author <> post_owner THEN
+      PERFORM public._feed_notify(
+        parent_author, NEW.user_id, 'reply_to_comment',
+        NEW.post_id, NEW.id);
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feed_notify_on_comment
+  AFTER INSERT ON public.feed_comments
+  FOR EACH ROW EXECUTE FUNCTION public._feed_notify_on_comment();
+
+-- New post → notify each follower of the author.
+CREATE OR REPLACE FUNCTION public._feed_notify_on_post()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.feed_notifications
+    (user_id, actor_id, kind, post_id, comment_id)
+  SELECT f.follower_id, NEW.user_id, 'friend_post', NEW.id, NULL
+  FROM public.feed_follows f
+  WHERE f.followee_id = NEW.user_id
+    AND NOT public._feed_either_blocks(f.follower_id, NEW.user_id);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feed_notify_on_post
+  AFTER INSERT ON public.feed_posts
+  FOR EACH ROW EXECUTE FUNCTION public._feed_notify_on_post();
+
+-- Upvote on a post → notify the post owner. Downvotes are ignored
+-- (no point pinging someone about a downvote). On vote flips we'd
+-- get a duplicate row; the client groups by (kind, post_id) in the
+-- inbox to keep the visual list tidy.
+CREATE OR REPLACE FUNCTION public._feed_notify_on_post_vote()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  post_owner UUID;
+BEGIN
+  IF NEW.value <= 0 THEN RETURN NEW; END IF;
+  SELECT user_id INTO post_owner FROM public.feed_posts WHERE id = NEW.post_id;
+  PERFORM public._feed_notify(
+    post_owner, NEW.user_id, 'post_upvote', NEW.post_id, NULL);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feed_notify_on_post_vote
+  AFTER INSERT ON public.feed_post_votes
+  FOR EACH ROW EXECUTE FUNCTION public._feed_notify_on_post_vote();
+
+-- Upvote on a comment → notify the comment owner. Same rules as posts.
+CREATE OR REPLACE FUNCTION public._feed_notify_on_comment_vote()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  comment_owner UUID;
+  parent_post UUID;
+BEGIN
+  IF NEW.value <= 0 THEN RETURN NEW; END IF;
+  SELECT user_id, post_id INTO comment_owner, parent_post
+    FROM public.feed_comments WHERE id = NEW.comment_id;
+  PERFORM public._feed_notify(
+    comment_owner, NEW.user_id, 'comment_upvote',
+    parent_post, NEW.comment_id);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feed_notify_on_comment_vote
+  AFTER INSERT ON public.feed_comment_votes
+  FOR EACH ROW EXECUTE FUNCTION public._feed_notify_on_comment_vote();
+
+COMMENT ON TABLE public.feed_notifications IS
+  'Per-user notification feed for social events. Populated by AFTER '
+  'INSERT triggers on feed_follows / feed_comments / feed_posts / '
+  'feed_post_votes / feed_comment_votes. Polled by the mobile client; '
+  'no Realtime subscription.';

--- a/supabase/migrations/20260524000000_feed_reactions.sql
+++ b/supabase/migrations/20260524000000_feed_reactions.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Feed: emoji reactions on posts and comments
+-- ============================================================
+-- One row per user / target. `target_kind` discriminates between
+-- posts and comments so a single table backs both. A user can
+-- only have ONE reaction per target — tapping a different emoji
+-- replaces the previous one (upsert on the PK). Tapping the same
+-- emoji clears it (delete).
+--
+-- The set of allowed emoji is enforced server-side via CHECK so
+-- the client can't smuggle arbitrary strings into the column.
+-- Add to the CHECK list when you add a new picker option.
+--
+-- RLS mirrors feed_comment_votes: world-readable for the per-target
+-- aggregates everyone sees, but only the owner can write their own
+-- row. Hiding reactions from blocked users is done client-side in
+-- the app query (same pattern as feed_posts), not in RLS.
+
+-- ── feed_reactions ───────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.feed_reactions (
+  user_id     UUID        NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  target_kind TEXT        NOT NULL CHECK (target_kind IN ('post', 'comment')),
+  target_id   UUID        NOT NULL,
+  emoji       TEXT        NOT NULL
+    CHECK (emoji IN ('❤️', '🔥', '😂', '😢', '🤔', '👏')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, target_kind, target_id)
+);
+
+-- Lookups are always "give me all reactions for these targets" —
+-- the index supports both the per-target join and the post-list
+-- fan-in used by the feed screen.
+CREATE INDEX IF NOT EXISTS feed_reactions_target_idx
+  ON public.feed_reactions (target_kind, target_id);
+
+ALTER TABLE public.feed_reactions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "feed_reactions_select" ON public.feed_reactions
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "feed_reactions_insert" ON public.feed_reactions
+  FOR INSERT TO authenticated WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "feed_reactions_update" ON public.feed_reactions
+  FOR UPDATE TO authenticated USING (auth.uid() = user_id);
+CREATE POLICY "feed_reactions_delete" ON public.feed_reactions
+  FOR DELETE TO authenticated USING (auth.uid() = user_id);

--- a/supabase/migrations/20260524020000_feed_pick_sends.sql
+++ b/supabase/migrations/20260524020000_feed_pick_sends.sql
@@ -1,0 +1,68 @@
+-- ============================================================
+-- feed_pick_sends: "send this pick to a friend"
+-- ============================================================
+-- Lightweight DM-style surface that reuses the existing post graph
+-- — sender + recipient + post + optional one-liner. Not a chat
+-- thread (no replies, no thread continuation) — that's a much
+-- bigger feature that can come later.
+--
+-- Recipient surfaces the send via the existing feed_notifications
+-- inbox: an AFTER-INSERT trigger fires `_feed_notify` with a new
+-- 'pick_sent' kind so the bell badge, mute toggles, and inbox card
+-- all work without any new client-side plumbing.
+--
+-- Same pick can be sent to the same person multiple times (e.g.
+-- "have you read this yet??" follow-up) — we deliberately do NOT
+-- add a UNIQUE (sender, recipient, post). The notification list
+-- will show each send as its own row.
+
+-- Add 'pick_sent' to the enum first so the trigger body can use it.
+-- ALTER TYPE ADD VALUE has to be its own statement; can't be in a
+-- block with the table that references it.
+ALTER TYPE public.feed_notification_kind ADD VALUE IF NOT EXISTS 'pick_sent';
+
+CREATE TABLE IF NOT EXISTS public.feed_pick_sends (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  sender_id    UUID        NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  recipient_id UUID        NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  post_id      UUID        NOT NULL REFERENCES public.feed_posts (id) ON DELETE CASCADE,
+  message      TEXT,
+  sent_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (sender_id <> recipient_id)
+);
+
+CREATE INDEX IF NOT EXISTS feed_pick_sends_recipient_idx
+  ON public.feed_pick_sends (recipient_id, sent_at DESC);
+CREATE INDEX IF NOT EXISTS feed_pick_sends_sender_idx
+  ON public.feed_pick_sends (sender_id, sent_at DESC);
+
+ALTER TABLE public.feed_pick_sends ENABLE ROW LEVEL SECURITY;
+
+-- Sender + recipient can both SELECT; sender INSERTs; either can
+-- DELETE (sender can unsend, recipient can dismiss / archive).
+CREATE POLICY "feed_pick_sends_select" ON public.feed_pick_sends
+  FOR SELECT TO authenticated
+  USING (auth.uid() = sender_id OR auth.uid() = recipient_id);
+CREATE POLICY "feed_pick_sends_insert" ON public.feed_pick_sends
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = sender_id);
+CREATE POLICY "feed_pick_sends_delete" ON public.feed_pick_sends
+  FOR DELETE TO authenticated
+  USING (auth.uid() = sender_id OR auth.uid() = recipient_id);
+
+-- Notify the recipient via the existing feed_notifications inbox.
+-- Reuses the shared _feed_notify helper, which skips the row if the
+-- recipient has blocked the sender (or vice versa).
+CREATE OR REPLACE FUNCTION public._feed_notify_on_pick_send()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+BEGIN
+  PERFORM public._feed_notify(
+    NEW.recipient_id, NEW.sender_id, 'pick_sent', NEW.post_id, NULL);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feed_notify_on_pick_send
+  AFTER INSERT ON public.feed_pick_sends
+  FOR EACH ROW EXECUTE FUNCTION public._feed_notify_on_pick_send();


### PR DESCRIPTION
profiles_select on profiles is owner-only, so embedding author:profiles(...) from feed_posts/feed_comments returned NULL for any row other than your own — cascading to "Someone" display names on the web feed whenever the viewer was logged in as another account.

The fix is a profiles_public view (security_invoker = false) that exposes only public-safe columns (id, name, username, avatar_url, bio, interests, tags, library_public, created_at), granted to authenticated/anon. Sensitive columns stay locked behind the owner-only policy on the base table. The same migration ships alongside the mobile commit on feat/flutter-app; deploying it once covers both clients. feed-service.ts embeds at every callsite switched to profiles_public.

Dedicated report screen replaces window.prompt
- New /feed/report?postId= / ?commentId= page. Reason radio list (spam · harassment · hate · violence · sexual · misinformation · other), optional details textarea, Submit. Reason key + free-text combine into the existing feed_reports.reason column.
- post-menu Report and comment-row Report buttons now push to the page via router.push; the old window.prompt and the useReportPost / useReportComment hooks (still exported from use-feed.ts for the new page itself) are no longer called from the menus.

npm run typecheck clean. npm run lint clean (only pre-existing warnings). 104/104 tests pass.